### PR TITLE
Implement Tuned Lens for improved layer-wise predictions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -83,3 +83,6 @@ check_*.py
 *_FIX.md
 *_SUMMARY.md
 scratch.*
+
+# Blog
+blog/

--- a/blog/introducing-mlxterp.md
+++ b/blog/introducing-mlxterp.md
@@ -1,0 +1,387 @@
+# Democratizing Mechanistic Interpretability: Bringing Neural Network Analysis to Apple Silicon
+
+*How unified memory architecture and thoughtful API design are making interpretability research accessible to researchers everywhere*
+
+**January 2025 | COAI Research Institute**
+
+---
+
+## Abstract
+
+Mechanistic interpretability—the systematic study of how neural networks implement learned algorithms—has emerged as one of the most promising approaches to understanding and ensuring the safety of advanced AI systems. However, the computational requirements of interpretability research have historically limited participation to well-resourced institutions with access to expensive GPU clusters. In this article, we introduce mlxterp, an open-source library that leverages Apple Silicon's unified memory architecture to enable sophisticated interpretability research on consumer hardware. We discuss the scientific motivations behind mechanistic interpretability, analyze the unique advantages of unified memory for activation analysis, and demonstrate how mlxterp's API design facilitates seamless transitions between local experimentation and cloud-scale validation. Our goal is not merely to provide a tool, but to lower barriers to entry for a field that urgently needs broader participation.
+
+---
+
+## 1. Introduction: The Interpretability Imperative
+
+The rapid advancement of large language models has created an unprecedented situation in the history of technology: we are deploying systems whose capabilities exceed our understanding of their internal mechanisms. A model like GPT-4 or Claude can engage in sophisticated reasoning, demonstrate apparent creativity, and exhibit behaviors that surprise even its creators—yet we lack fundamental insight into *how* these capabilities emerge from the model's learned parameters.
+
+This epistemic gap poses significant challenges. Without understanding why a model produces particular outputs, we cannot reliably predict when it will fail, detect when it might be engaging in deceptive behavior, or confidently align its objectives with human values. The field of mechanistic interpretability has emerged as a response to these challenges, seeking to reverse-engineer neural networks much as biologists reverse-engineer biological systems or security researchers reverse-engineer software.
+
+The core premise of mechanistic interpretability is that neural networks, despite their complexity, implement interpretable algorithms that can be discovered through careful analysis. This premise has been validated by numerous research successes: the discovery of "induction heads" that implement in-context learning (Olsson et al., 2022), the identification of circuits responsible for indirect object identification (Wang et al., 2022), and the extraction of features representing human-interpretable concepts from model activations (Cunningham et al., 2023).
+
+Yet despite these successes, mechanistic interpretability remains a relatively small field, practiced primarily at a handful of well-funded organizations. The reasons are partly computational: serious interpretability work requires capturing and analyzing activations from models with billions of parameters, running numerous experiments with different interventions, and iterating rapidly through hypotheses. These requirements have traditionally demanded expensive cloud GPU access, creating barriers that exclude many potential contributors.
+
+We believe this exclusion is not merely unfortunate but actively harmful to the field's progress. Interpretability research benefits enormously from diverse perspectives—researchers with different backgrounds notice different patterns, ask different questions, and develop different intuitions. By limiting participation to those with institutional resources, we are limiting the field's intellectual diversity at precisely the moment when it most needs fresh thinking.
+
+mlxterp represents our attempt to address this problem by exploiting a technological development that makes high-quality interpretability research possible on consumer hardware: Apple Silicon's unified memory architecture.
+
+---
+
+## 2. Background: The Science of Mechanistic Interpretability
+
+### 2.1 From Black Boxes to Mechanistic Understanding
+
+Neural networks have long been described as "black boxes"—systems that transform inputs to outputs through processes too complex for humans to understand. This characterization, while historically reasonable, increasingly appears to be a limitation of our tools rather than an inherent property of the systems themselves.
+
+The mechanistic interpretability research program is founded on the hypothesis that neural networks implement relatively simple algorithms, but do so in a distributed manner across many parameters. The goal is to identify these algorithms—termed "circuits"—and understand how they compose to produce the network's overall behavior.
+
+Consider a simple example: how does a language model complete the phrase "The Eiffel Tower is located in"? A mechanistic account might reveal that:
+
+1. Early layers identify "Eiffel Tower" as a named entity requiring geographic information
+2. Middle layers retrieve the association between "Eiffel Tower" and "Paris" from the model's parametric memory
+3. Late layers format this retrieved information as an appropriate completion
+
+Each of these steps might be implemented by specific "circuits"—patterns of connectivity and computation that perform identifiable functions. Discovering these circuits allows us to understand not just *what* the model does, but *how* and *why* it does it.
+
+### 2.2 Key Techniques in Mechanistic Interpretability
+
+The field has developed several core techniques for investigating neural network internals:
+
+**Activation Analysis** involves capturing the intermediate computations (activations) produced by a model during inference and analyzing their properties. This includes examining activation magnitudes, correlations between activations and input features, and how activations evolve through the network's layers. The "logit lens" technique (nostalgebraist, 2020) exemplifies this approach, projecting intermediate activations to vocabulary space to reveal what the model "believes" at each layer.
+
+**Causal Interventions** go beyond passive observation to actively modify activations and observe the effects on model behavior. If zeroing out a particular component causes the model to lose a specific capability, this provides causal evidence that the component is involved in implementing that capability. Activation patching (Vig et al., 2020) and path patching (Goldowsky-Dill et al., 2023) are sophisticated variants that allow researchers to precisely localize the sources of model behaviors.
+
+**Feature Extraction** attempts to identify interpretable directions in activation space. Sparse autoencoders (Cunningham et al., 2023; Bricken et al., 2023) have proven particularly effective, learning to decompose activations into sparse combinations of human-interpretable features. This technique has revealed that models learn rich representations of concepts like "code," "deception," and "uncertainty" that can be analyzed and potentially controlled.
+
+**Circuit Discovery** synthesizes these techniques to identify complete computational subgraphs responsible for specific behaviors. The goal is to produce explanations at the level of "attention head A in layer 3 moves information from the subject token to the final position, where MLP neuron B looks up the associated attribute."
+
+### 2.3 The Computational Challenge
+
+These techniques, while conceptually straightforward, impose significant computational demands. Consider what's required to perform a simple activation patching experiment:
+
+1. Run the model on a "clean" input and cache all intermediate activations
+2. Run the model on a "corrupted" input, intervening to replace specific activations with their clean counterparts
+3. Measure the effect on output probabilities
+4. Repeat for each component of interest (potentially thousands of attention heads and MLP neurons)
+
+For a model with 32 layers, each containing multiple attention heads and an MLP, a comprehensive patching sweep requires thousands of forward passes, each producing gigabytes of activation data. Multiply this by the number of examples needed for statistical reliability, and the computational requirements become substantial.
+
+Traditional GPU computing imposes additional overhead: activations must be copied from GPU memory to CPU memory for analysis, creating a bottleneck that slows iterative research workflows. Researchers frequently report spending more time managing memory and waiting for data transfers than actually analyzing results.
+
+---
+
+## 3. The Apple Silicon Opportunity
+
+### 3.1 Unified Memory Architecture
+
+Apple Silicon's most significant innovation for machine learning workloads is not its raw computational speed but its memory architecture. Traditional computing systems maintain separate memory pools for CPU and GPU, requiring explicit data transfers between them. This separation made sense historically—GPUs were discrete cards with their own DRAM, physically separate from the CPU's memory.
+
+Apple's system-on-chip design eliminates this separation. The M1, M2, M3, and M4 families feature unified memory that is directly accessible to all processing units—CPU cores, GPU cores, and Neural Engine—at full bandwidth. When a computation produces results on the GPU, those results are immediately available to the CPU without any copying.
+
+The implications for interpretability research are profound. Capturing activations no longer requires expensive GPU-to-CPU transfers. An activation tensor produced by a transformer layer can be analyzed by CPU code, visualized in a plotting library, and saved to disk, all without ever being copied. The unified memory pool can also be much larger than discrete GPU memory—current configurations support up to 192GB, far exceeding the 80GB available on even the most expensive data center GPUs.
+
+### 3.2 Quantitative Analysis
+
+To appreciate the practical impact, consider the memory requirements for interpretability work on a 7B parameter model:
+
+- Model parameters (4-bit quantized): ~3.5GB
+- Key-value cache for 2048 tokens: ~1GB
+- Intermediate activations (all layers): ~2-4GB per forward pass
+- Analysis workspace: Variable, often 10-50GB for batch analysis
+
+On a traditional system with 24GB GPU memory, researchers must carefully manage what fits in GPU memory, often forcing compromises between model size, sequence length, and activation caching. Running out of memory mid-experiment is a common frustration.
+
+On an Apple Silicon system with 64GB or more of unified memory, these constraints largely disappear. The entire workflow—model inference, activation capture, statistical analysis, visualization—operates within a single coherent memory space. More importantly, the absence of memory copies means that capturing activations has minimal overhead compared to simply running inference.
+
+### 3.3 Economic Considerations
+
+Beyond technical advantages, unified memory architecture has significant economic implications for research accessibility. Cloud GPU instances with sufficient memory for serious interpretability work cost $2-8 per hour, depending on provider and GPU type. A researcher running experiments for 8 hours daily would face monthly costs of $400-$1,600—a substantial burden for unfunded researchers, students, or those at institutions without cloud computing budgets.
+
+Apple Silicon hardware, while requiring upfront investment, has no ongoing costs. A MacBook Pro or Mac Studio, once purchased, can run unlimited interpretability experiments. For researchers who expect to work in this area for years, the economics strongly favor local hardware.
+
+Moreover, cloud computing introduces friction that impedes the kind of rapid iteration that drives scientific progress. Starting a cloud instance, waiting for model loading, and managing session state all add overhead that discourages exploratory analysis. Local computing enables immediate experimentation—a researcher can have a new idea and be testing it within seconds.
+
+---
+
+## 4. Design Philosophy: Learning from Existing Tools
+
+### 4.1 The Interpretability Tool Landscape
+
+Several excellent interpretability libraries have been developed for PyTorch, most notably TransformerLens (Nanda, 2022) and nnsight (Fiotto-Kaufman et al., 2024). These tools have demonstrated the value of well-designed abstractions for interpretability research, and mlxterp draws heavily on their insights.
+
+TransformerLens pioneered the idea of "hooking" into transformer computations, providing clean access to attention patterns, residual stream contributions, and other internals. Its comprehensive API has enabled much of the field's empirical work. However, TransformerLens requires model-specific implementations—each architecture needs its own "hooked" version—limiting its applicability to a curated set of models.
+
+nnsight took a different approach, using Python's meta-programming capabilities to wrap arbitrary PyTorch models without requiring model-specific code. This "model-agnostic" design philosophy means nnsight can work with any PyTorch model, dramatically expanding its applicability. nnsight also pioneered the concept of remote execution, allowing researchers to run interpretability experiments on models hosted by infrastructure providers like NDIF (National Deep Inference Fabric).
+
+### 4.2 Design Decisions in mlxterp
+
+mlxterp synthesizes insights from both approaches while adapting to MLX's programming model. Our key design decisions include:
+
+**Model-Agnostic Wrapping**: Like nnsight, mlxterp works with arbitrary MLX models through recursive module discovery. When you wrap a model with `InterpretableModel`, mlxterp traverses the module tree, identifies all computational components, and installs transparent wrappers that capture activations and enable interventions. No model-specific code is required.
+
+**Context Manager Tracing**: Both nnsight and mlxterp use Python context managers to delineate the scope of tracing operations. This pattern makes code intent explicit—everything inside the `with model.trace():` block is subject to tracing—and ensures proper cleanup of temporary state.
+
+**Lazy Evaluation Integration**: MLX, like JAX, uses lazy evaluation—computations are not executed until their results are needed. mlxterp embraces this paradigm rather than fighting it. When you call `.save()` on an activation, you're not immediately capturing data; you're marking that activation for capture when the computation graph eventually executes.
+
+**API Compatibility**: We deliberately designed mlxterp's API to feel familiar to nnsight users. This isn't merely about reducing learning curves—it's about enabling a research workflow where techniques developed locally on Apple Silicon can be directly applied to larger models via nnsight's remote execution capabilities.
+
+### 4.3 The Local-to-Cloud Research Pathway
+
+This last point deserves elaboration. Mechanistic interpretability research typically proceeds through stages:
+
+1. **Hypothesis Formation**: Initial ideas emerge from intuition, prior work, or unexpected observations
+2. **Rapid Prototyping**: Quick experiments test whether an idea has merit
+3. **Careful Validation**: Promising findings are validated with more rigorous methodology
+4. **Scaling Verification**: Results are confirmed on larger, more capable models
+
+Different stages have different computational requirements. Hypothesis formation and rapid prototyping benefit from immediate feedback and low friction—exactly what local computing provides. Careful validation may require more examples or longer sequences, potentially exceeding local resources. Scaling verification definitionally requires access to larger models than can run locally.
+
+By designing mlxterp's API to mirror nnsight's, we enable researchers to move fluidly between stages. A technique developed and debugged locally can be applied to frontier models via NDIF (ndif.us) or EDIF (edif.ai) with minimal code changes. The same mental models, the same patterns of investigation, transfer across the local-cloud boundary.
+
+This design also future-proofs research workflows. As Apple Silicon capabilities increase (current M4 Max systems support 128GB unified memory; future systems will likely support more), the range of models analyzable locally will expand. Research techniques developed today will continue working as hardware improves.
+
+---
+
+## 5. Technical Implementation
+
+### 5.1 Activation Capture Architecture
+
+At its core, mlxterp implements a transparent interposition layer between model components and their callers. When a model is wrapped with `InterpretableModel`, each submodule is wrapped with a lightweight proxy that:
+
+1. Intercepts calls to the original module
+2. Invokes the original computation
+3. Stores the output in a shared activation dictionary
+4. Returns the output (potentially modified by interventions) to the caller
+
+This design has several important properties. First, it preserves the original model's behavior exactly when no interventions are active—the proxy simply passes through computations. Second, it captures activations at the granularity of individual modules, providing access to attention outputs, MLP intermediates, and layer normalizations separately. Third, it imposes minimal overhead, as the interposition layer adds only dictionary storage operations to the critical path.
+
+The activation dictionary is keyed by the full path to each module (e.g., `model.model.layers.5.self_attn.q_proj`), providing a systematic naming scheme that works across different model architectures. For a typical transformer model, this results in approximately 196 captured activations per forward pass—far more than most research requires, but available when fine-grained analysis is needed.
+
+### 5.2 The Intervention System
+
+Interventions—modifications to activations during the forward pass—are central to causal interpretability methods. mlxterp provides a composable intervention system that supports common operations while remaining extensible.
+
+Built-in interventions include:
+
+- **Zeroing**: Set activations to zero, removing a component's contribution
+- **Scaling**: Multiply activations by a constant, attenuating or amplifying effects
+- **Addition**: Add a vector to activations, implementing steering or ablation
+- **Replacement**: Replace activations entirely, implementing activation patching
+- **Clamping**: Restrict activations to a range, testing saturation effects
+- **Noise**: Add Gaussian noise, testing robustness to perturbation
+
+These interventions can be composed, allowing complex experimental manipulations to be expressed concisely. A researcher might scale an activation by 0.5, add noise, and then clamp the result—all in a single composed intervention.
+
+For cases where built-in interventions are insufficient, arbitrary Python functions can serve as interventions. Any function that accepts an activation tensor and returns a modified tensor can be used, enabling experimentation with novel manipulation strategies.
+
+### 5.3 Analysis Methods
+
+Beyond infrastructure for activation capture and intervention, mlxterp provides implementations of common interpretability analyses:
+
+**Logit Lens** (nostalgebraist, 2020): Projects intermediate activations to vocabulary space by applying the model's unembedding matrix. This reveals what "prediction" each layer would make if it were the final layer, showing how the model builds up its answer through successive refinements. mlxterp's implementation handles the complexity of weight-tied embeddings and final layer normalization automatically.
+
+**Tuned Lens** (Belrose et al., 2023): An improvement on the logit lens that learns a small affine transformation for each layer to correct for coordinate system differences between layers. This produces more accurate intermediate predictions, particularly for early layers. mlxterp includes both training code and inference support for tuned lens analysis.
+
+**Activation Patching**: A systematic method for identifying which components are causally important for a particular behavior. mlxterp's implementation automates the process of running clean and corrupted inputs, patching activations, and measuring recovery, producing results that can be immediately visualized.
+
+---
+
+## 6. Practical Applications
+
+To ground these abstractions in concrete research practice, we present several example applications that illustrate mlxterp's capabilities.
+
+### 6.1 Investigating Factual Recall
+
+A fundamental question in language model interpretability is how models store and retrieve factual knowledge. When a model correctly completes "The capital of France is" with "Paris," where does this knowledge come from? Is it distributed across many layers, or localized in specific components?
+
+Using mlxterp, we can investigate this question through activation patching:
+
+```python
+from mlxterp import InterpretableModel
+
+model = InterpretableModel("mlx-community/Llama-3.2-1B-Instruct")
+
+# Test which MLP layers are important for factual recall
+results = model.activation_patching(
+    clean_text="The capital of France is Paris",
+    corrupted_text="The capital of France is London",
+    component="mlp",
+    plot=True
+)
+
+# Identify the most important layers
+sorted_results = sorted(results.items(), key=lambda x: x[1], reverse=True)
+for layer_idx, recovery in sorted_results[:5]:
+    print(f"Layer {layer_idx}: {recovery:.1f}% recovery")
+```
+
+This experiment reveals which layers are most critical for producing the correct factual completion. High recovery percentages indicate layers where the model's "knowledge" of Paris being France's capital is concentrated. Research using similar methodology has shown that factual knowledge often localizes in middle layers' MLP components, consistent with theories that MLPs serve as key-value memories (Geva et al., 2021).
+
+### 6.2 Tracing Prediction Evolution
+
+The logit lens technique allows us to trace how a model's predictions evolve through its layers:
+
+```python
+# Analyze prediction evolution
+results = model.logit_lens(
+    "The Eiffel Tower is located in the city of",
+    layers=list(range(16)),
+    plot=True
+)
+
+# Print predictions at the final token position
+for layer_idx in range(0, 16, 4):
+    prediction = results[layer_idx][-1][0][2]  # Top prediction at last position
+    print(f"Layer {layer_idx}: predicts '{prediction}'")
+```
+
+This analysis typically reveals a characteristic pattern: early layers make generic predictions (common words like "the" or "a"), middle layers begin to incorporate context (perhaps "Paris" or "France"), and late layers converge on the correct answer with high confidence. Deviations from this pattern can indicate interesting model behaviors worth investigating.
+
+### 6.3 Developing Steering Vectors
+
+Activation steering has emerged as a promising technique for controlling model behavior without fine-tuning. The basic approach computes a "steering vector" as the difference between activations for contrasting prompts, then adds this vector during inference to bias the model toward desired behaviors.
+
+```python
+import mlx.core as mx
+from mlxterp import interventions as iv
+
+# Compute steering vector from contrastive examples
+with model.trace("I think this is absolutely wonderful and amazing") as positive:
+    pos_activation = positive.activations['model.model.layers.10']
+
+with model.trace("I think this is terrible and disappointing") as negative:
+    neg_activation = negative.activations['model.model.layers.10']
+
+# Compute difference as steering vector
+sentiment_vector = pos_activation.mean(axis=1) - neg_activation.mean(axis=1)
+
+# Apply steering to a neutral prompt
+with model.trace(
+    "The movie was",
+    interventions={'model.model.layers.10': iv.add_vector(sentiment_vector * 2.0)}
+) as steered:
+    output_logits = steered.activations['__model_output__']
+```
+
+mlxterp's low-overhead activation capture makes it practical to iterate rapidly on steering vector development, testing different layers, scaling factors, and contrastive example pairs.
+
+---
+
+## 7. Relationship to Remote Inference Infrastructure
+
+### 7.1 The NDIF and EDIF Ecosystem
+
+The interpretability research community has developed shared infrastructure for accessing large models. The National Deep Inference Fabric (NDIF) provides U.S. researchers with free access to frontier models for academic research. The European Deep Inference Fabric (EDIF) serves a similar role for European researchers. Both services use nnsight's remote execution capabilities, allowing researchers to run interpretability experiments on models too large for local deployment.
+
+These services represent a significant democratization of access to frontier model internals. A researcher at a small institution can now run activation patching experiments on 70B parameter models without any GPU infrastructure—the computation happens on NDIF's servers, with only the results returned to the researcher.
+
+### 7.2 Complementary Workflows
+
+mlxterp and remote inference services are complements, not substitutes. Local computing excels for rapid iteration, debugging, and exploratory analysis—situations where minimizing latency between idea and result maximizes productivity. Remote computing enables scaling to models beyond local capacity and provides access to frontier capabilities that may not have efficient local implementations.
+
+The ideal workflow leverages both: develop and refine techniques locally on smaller models using mlxterp, then validate findings on larger models via nnsight and NDIF. Because the two systems share API patterns, this transition is smooth—the same mental models and much of the same code transfer across the boundary.
+
+This complementarity also provides a natural growth path for researchers. Someone new to interpretability can begin with purely local work using mlxterp, building intuition and developing techniques. As they tackle more ambitious questions requiring larger models, they can gradually incorporate remote resources without abandoning their local development workflow.
+
+---
+
+## 8. Current Limitations and Future Directions
+
+### 8.1 Limitations
+
+We acknowledge several limitations of the current mlxterp implementation:
+
+**Model Size Constraints**: While Apple Silicon's unified memory supports larger models than discrete GPUs, there are still limits. A 70B parameter model, even with aggressive quantization, requires more memory than current consumer hardware provides. Truly frontier-scale research still requires cloud resources.
+
+**Ecosystem Maturity**: The MLX ecosystem is younger than PyTorch's, with fewer pre-trained models, less community tooling, and ongoing API evolution. Researchers may need to convert models from other formats or work around missing features.
+
+**Performance Optimization**: While unified memory eliminates copy overhead, MLX's computational performance is still maturing. Some operations may be slower than optimized CUDA implementations, though for interpretability work (where activation capture dominates runtime), this is often acceptable.
+
+### 8.2 Planned Developments
+
+We are actively developing several extensions to mlxterp:
+
+**Sparse Autoencoder Support**: SAEs have become central to modern interpretability research, revealing interpretable features in model activations. We are implementing SAE training on captured activations and compatibility with existing SAE formats (particularly SAELens), enabling feature-based analysis workflows.
+
+**Attention Pattern Analysis**: Built-in tools for analyzing attention patterns, including visualization, pattern matching across examples, and statistical characterization of attention head behaviors.
+
+**Circuit Extraction Tools**: Semi-automated tools for identifying and extracting circuits, building on activation patching to provide higher-level abstractions for circuit discovery.
+
+**Enhanced NDIF Integration**: Tighter integration with nnsight for seamless local-to-remote transitions, potentially including unified result formats and analysis tools that work across both execution modes.
+
+### 8.3 Long-Term Vision
+
+Looking further ahead, we envision interpretability tooling that enables qualitatively new research paradigms:
+
+**Real-Time Interpretability**: Analyzing model behavior during generation, with interventions that adapt based on intermediate computations. This could enable dynamic steering that responds to detected model states.
+
+**Interpretability-Informed Training**: Using insights from interpretability research to guide model development, potentially training models that are more interpretable by design.
+
+**Automated Hypothesis Generation**: Tools that not only test hypotheses but help generate them, identifying anomalous patterns that warrant investigation.
+
+These directions require not just better tools but better scientific understanding of neural network computation. We hope that by lowering barriers to interpretability research, mlxterp will contribute to the diverse research community needed to achieve this understanding.
+
+---
+
+## 9. Conclusion
+
+Mechanistic interpretability represents one of our best hopes for understanding and ensuring the safety of advanced AI systems. Yet the field's progress has been limited by computational barriers that exclude many potential contributors. The combination of Apple Silicon's unified memory architecture and thoughtfully designed software tools like mlxterp offers a path to broader participation.
+
+We have presented mlxterp not merely as a technical artifact but as part of a broader vision for democratized interpretability research. By enabling serious interpretability work on consumer hardware, by designing APIs that facilitate transitions to cloud resources when needed, and by contributing to an ecosystem of compatible tools, we hope to accelerate progress on questions that matter enormously for humanity's future with AI.
+
+The challenges ahead are significant. We do not fully understand how neural networks implement the capabilities they exhibit, how to reliably detect undesirable behaviors, or how to align AI systems with human values. These are not problems that any single tool or research group will solve. They require the collective effort of a large, diverse community of researchers bringing different perspectives and approaches.
+
+mlxterp is our contribution to building that community. We invite researchers to use these tools, extend them, and share what they learn. The source code is available at github.com/coairesearch/mlxterp, and we welcome contributions of all kinds.
+
+Understanding the systems we build is not optional—it is a prerequisite for building systems we can trust. We hope mlxterp makes that understanding a little more accessible.
+
+---
+
+## References
+
+Belrose, N., Furman, Z., Smith, L., Halawi, D., Ostrovsky, I., McKinney, L., ... & Steinhardt, J. (2023). Eliciting latent predictions from transformers with the tuned lens. *arXiv preprint arXiv:2303.08112*.
+
+Bricken, T., Templeton, A., Batson, J., Chen, B., Jermyn, A., Conerly, T., ... & Olah, C. (2023). Towards monosemanticity: Decomposing language models with dictionary learning. *Transformer Circuits Thread*.
+
+Cunningham, H., Ewart, A., Riggs, L., Huben, R., & Sharkey, L. (2023). Sparse autoencoders find highly interpretable features in language models. *arXiv preprint arXiv:2309.08600*.
+
+Fiotto-Kaufman, J., Loftus, A., Todd, E., Brinkmann, J., Juang, C., Pal, K., ... & Bau, D. (2024). NNsight and NDIF: Democratizing access to foundation model internals. *arXiv preprint arXiv:2407.14561*.
+
+Geva, M., Schuster, R., Berant, J., & Levy, O. (2021). Transformer feed-forward layers are key-value memories. *arXiv preprint arXiv:2012.14913*.
+
+Goldowsky-Dill, N., MacLeod, C., Sato, L., & Arora, A. (2023). Localizing model behavior with path patching. *arXiv preprint arXiv:2304.05969*.
+
+Nanda, N. (2022). TransformerLens. GitHub repository. https://github.com/neelnanda-io/TransformerLens
+
+nostalgebraist. (2020). interpreting GPT: the logit lens. *LessWrong*.
+
+Olsson, C., Elhage, N., Nanda, N., Joseph, N., DasSarma, N., Henighan, T., ... & Olah, C. (2022). In-context learning and induction heads. *Transformer Circuits Thread*.
+
+Vig, J., Gehrmann, S., Belinkov, Y., Qian, S., Nevo, D., Singer, Y., & Shieber, S. (2020). Investigating gender bias in language models using causal mediation analysis. *Advances in Neural Information Processing Systems*.
+
+Wang, K., Variengien, A., Conmy, A., Shlegeris, B., & Steinhardt, J. (2022). Interpretability in the wild: a circuit for indirect object identification in GPT-2 small. *arXiv preprint arXiv:2211.00593*.
+
+---
+
+## Acknowledgments
+
+We thank the developers of nnsight, TransformerLens, and the broader interpretability research community for their foundational work that mlxterp builds upon. We also thank Apple's MLX team for creating a framework that makes this work possible.
+
+---
+
+## Citation
+
+```bibtex
+@software{mlxterp2025,
+  title = {mlxterp: Mechanistic Interpretability for MLX on Apple Silicon},
+  author = {Schacht, Sigurd and {COAI Research Institute}},
+  year = {2025},
+  url = {https://github.com/coairesearch/mlxterp},
+  note = {Open source library for neural network interpretability research}
+}
+```
+
+---
+
+*For questions, feedback, or collaboration inquiries, please visit [coairesearch.org](https://coairesearch.org) or open an issue on our [GitHub repository](https://github.com/coairesearch/mlxterp).*

--- a/docs/API.md
+++ b/docs/API.md
@@ -471,7 +471,9 @@ model.tuned_lens(
     max_display_tokens: int = 15,
     figsize: tuple = (16, 10),
     cmap: str = 'viridis',
-    font_family: Optional[str] = None
+    font_family: Optional[str] = None,
+    final_norm: Any = None,
+    skip_norm: bool = False
 ) -> Dict[int, List[List[tuple]]]
 ```
 
@@ -487,6 +489,8 @@ model.tuned_lens(
 - **figsize** (`tuple`, default: `(16, 10)`): Figure size for plot
 - **cmap** (`str`, default: `'viridis'`): Colormap for heatmap
 - **font_family** (`Optional[str]`): Font for plot (auto-detected if None)
+- **final_norm** (`Any`, default: `None`): Override for final layer norm. Pass a callable to use a custom norm.
+- **skip_norm** (`bool`, default: `False`): If True, skip final layer normalization (for models without it)
 
 **Returns:** Dict mapping `layer_idx` -> list of positions -> list of `(token_id, score, token_str)` tuples
 
@@ -536,7 +540,6 @@ model.train_tuned_lens(
     learning_rate: float = 1.0,
     momentum: float = 0.9,
     max_seq_len: int = 2048,
-    batch_size: int = 1,
     gradient_clip: float = 1.0,
     save_path: Optional[str] = None,
     verbose: bool = True,
@@ -551,13 +554,19 @@ model.train_tuned_lens(
 - **learning_rate** (`float`, default: `1.0`): Initial learning rate (uses linear decay)
 - **momentum** (`float`, default: `0.9`): Nesterov momentum coefficient
 - **max_seq_len** (`int`, default: `2048`): Maximum sequence length for training chunks
-- **batch_size** (`int`, default: `1`): Batch size
 - **gradient_clip** (`float`, default: `1.0`): Gradient clipping norm
 - **save_path** (`Optional[str]`): Path to save trained weights
 - **verbose** (`bool`, default: `True`): Print training progress
 - **callback** (`Optional[Callable]`): Callback function called with `(step, loss)` after each step
 
 **Returns:** Trained `TunedLens` instance
+
+**Raises:**
+
+- `ValueError`: If dataset is empty or contains only whitespace
+- `ValueError`: If dataset has fewer tokens than `max_seq_len`
+- `ValueError`: If `max_seq_len` is less than 10 tokens
+- `ValueError`: If model hidden dimension cannot be determined
 
 **Training Details (from paper):**
 - Optimizer: SGD with Nesterov momentum (0.9)

--- a/docs/API.md
+++ b/docs/API.md
@@ -454,14 +454,14 @@ results = model.logit_lens(
 
 ---
 
-#### Method: `tuned_logit_lens`
+#### Method: `tuned_lens`
 
 Apply tuned lens for improved layer-wise predictions.
 
 The tuned lens technique (Belrose et al., 2023) uses learned affine transformations for each layer to correct for coordinate system mismatches between layers, producing more accurate intermediate predictions than the standard logit lens.
 
 ```python
-model.tuned_logit_lens(
+model.tuned_lens(
     text: str,
     tuned_lens: TunedLens,
     top_k: int = 1,
@@ -508,7 +508,7 @@ tuned_lens = model.train_tuned_lens(
 tuned_lens = model.load_tuned_lens("tuned_lens_llama.npz")
 
 # Apply tuned lens
-results = model.tuned_logit_lens(
+results = model.tuned_lens(
     "The capital of France is",
     tuned_lens,
     layers=[0, 5, 10, 15],
@@ -604,7 +604,7 @@ model.load_tuned_lens(path: str) -> TunedLens
 
 ```python
 tuned_lens = model.load_tuned_lens("tuned_lens_llama.npz")
-results = model.tuned_logit_lens("Hello world", tuned_lens)
+results = model.tuned_lens("Hello world", tuned_lens)
 ```
 
 ---

--- a/docs/TUTORIAL_PAPERS_PLAN.md
+++ b/docs/TUTORIAL_PAPERS_PLAN.md
@@ -189,7 +189,7 @@ def train_tuned_lens(
     return tuned_lens
 
 
-def tuned_logit_lens(
+def tuned_lens(
     model: InterpretableModel,
     tuned_lens: TunedLens,
     text: str,
@@ -241,7 +241,7 @@ tuned_lens = train_tuned_lens(model, texts, num_steps=250)
 text = "The capital of France is"
 
 raw_results = model.logit_lens(text, layers=[0, 5, 10, 15])
-tuned_results = tuned_logit_lens(model, tuned_lens, text, layers=[0, 5, 10, 15])
+tuned_results = tuned_lens(model, tuned_lens, text, layers=[0, 5, 10, 15])
 
 print("Layer | Raw Logit Lens | Tuned Lens")
 print("-" * 45)

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -473,7 +473,7 @@ tuned_lens = model.load_tuned_lens("my_tuned_lens.npz")
 
 ```python
 # Apply tuned lens (similar API to logit_lens)
-results = model.tuned_logit_lens(
+results = model.tuned_lens(
     "The capital of France is",
     tuned_lens,
     layers=[0, 5, 10, 15]
@@ -496,7 +496,7 @@ text = "The capital of France is"
 regular = model.logit_lens(text, layers=[0, 5, 10, 15])
 
 # Tuned lens
-tuned = model.tuned_logit_lens(text, tuned_lens, layers=[0, 5, 10, 15])
+tuned = model.tuned_lens(text, tuned_lens, layers=[0, 5, 10, 15])
 
 print("Comparison: Logit Lens vs Tuned Lens")
 print("-" * 45)
@@ -513,7 +513,7 @@ for layer_idx in [0, 5, 10, 15]:
 
 ```python
 # Generate heatmap visualization
-results = model.tuned_logit_lens(
+results = model.tuned_lens(
     "The Eiffel Tower is located in the city of",
     tuned_lens,
     plot=True,

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -433,6 +433,97 @@ for prompt in prompts:
 # 'The capital of Italy is' -> ' Rome' (17.8)
 ```
 
+## Tuned Lens
+
+The tuned lens technique (Belrose et al., 2023) improves on the logit lens by learning small affine transformations for each layer that correct for coordinate system mismatches between layers.
+
+### Training a Tuned Lens
+
+```python
+from mlxterp import InterpretableModel
+
+# Load model
+model = InterpretableModel("mlx-community/Llama-3.2-1B-Instruct")
+
+# Prepare training data - any text corpus works
+training_texts = [
+    "The capital of France is Paris, which is known for the Eiffel Tower.",
+    "Machine learning is a branch of artificial intelligence.",
+    "Python is a popular programming language for data science.",
+    # Add more diverse training texts...
+]
+
+# Train tuned lens (takes a few minutes depending on dataset size)
+tuned_lens = model.train_tuned_lens(
+    dataset=training_texts,
+    num_steps=250,
+    save_path="my_tuned_lens.npz",  # Auto-saves config + weights
+    verbose=True
+)
+```
+
+### Loading a Pre-trained Tuned Lens
+
+```python
+# Load previously trained tuned lens
+tuned_lens = model.load_tuned_lens("my_tuned_lens.npz")
+```
+
+### Using the Tuned Lens
+
+```python
+# Apply tuned lens (similar API to logit_lens)
+results = model.tuned_logit_lens(
+    "The capital of France is",
+    tuned_lens,
+    layers=[0, 5, 10, 15]
+)
+
+# Print predictions at last position for each layer
+for layer_idx in sorted(results.keys()):
+    top_pred = results[layer_idx][-1][0]  # Last position, top prediction
+    token_str = top_pred[2]
+    score = top_pred[1]
+    print(f"Layer {layer_idx:2d}: '{token_str}' (score: {score:.2f})")
+```
+
+### Comparing Logit Lens vs Tuned Lens
+
+```python
+text = "The capital of France is"
+
+# Regular logit lens
+regular = model.logit_lens(text, layers=[0, 5, 10, 15])
+
+# Tuned lens
+tuned = model.tuned_logit_lens(text, tuned_lens, layers=[0, 5, 10, 15])
+
+print("Comparison: Logit Lens vs Tuned Lens")
+print("-" * 45)
+for layer_idx in [0, 5, 10, 15]:
+    reg_pred = regular[layer_idx][-1][0][2]  # Last pos, top pred
+    tun_pred = tuned[layer_idx][-1][0][2]
+    match = "=" if reg_pred == tun_pred else "!"
+    print(f"Layer {layer_idx:2d}: Regular='{reg_pred:>10}' | Tuned='{tun_pred:>10}' {match}")
+
+# Tuned lens often produces more accurate predictions in early layers
+```
+
+### Visualizing Tuned Lens Results
+
+```python
+# Generate heatmap visualization
+results = model.tuned_logit_lens(
+    "The Eiffel Tower is located in the city of",
+    tuned_lens,
+    plot=True,
+    max_display_tokens=15,
+    figsize=(16, 10)
+)
+```
+
+**Reference:** Belrose et al., "Eliciting Latent Predictions from Transformers with the Tuned Lens" (https://arxiv.org/abs/2303.08112)
+
 ## Activation Collection
 
 ### Collecting Specific Layers

--- a/mlxterp/__init__.py
+++ b/mlxterp/__init__.py
@@ -40,6 +40,7 @@ from .core import (
 )
 from .utils import get_activations, batch_get_activations
 from .sae import SAE, SAEConfig, SAETrainer
+from .tuned_lens import TunedLens, train_tuned_lens
 
 # Create interventions namespace for cleaner imports
 class _Interventions:
@@ -76,4 +77,7 @@ __all__ = [
     "SAE",
     "SAEConfig",
     "SAETrainer",
+    # Tuned Lens
+    "TunedLens",
+    "train_tuned_lens",
 ]

--- a/mlxterp/analysis.py
+++ b/mlxterp/analysis.py
@@ -435,7 +435,7 @@ class AnalysisMixin:
 
         return results
 
-    def tuned_logit_lens(
+    def tuned_lens(
         self,
         text: str,
         tuned_lens: Any,
@@ -479,7 +479,7 @@ class AnalysisMixin:
             >>> # tuned_lens = TunedLens.load("tuned_lens")  # Loads .npz and .json files
             >>>
             >>> # Apply tuned lens
-            >>> results = model.tuned_logit_lens(
+            >>> results = model.tuned_lens(
             ...     "The capital of France is",
             ...     tuned_lens,
             ...     layers=[0, 5, 10, 15],

--- a/mlxterp/analysis.py
+++ b/mlxterp/analysis.py
@@ -493,6 +493,7 @@ class AnalysisMixin:
             Belrose et al., "Eliciting Latent Predictions from Transformers with the Tuned Lens"
             https://arxiv.org/abs/2303.08112
         """
+        import warnings
         from .core.module_resolver import find_layer_key_pattern
 
         # Run trace to get all layer outputs

--- a/mlxterp/analysis.py
+++ b/mlxterp/analysis.py
@@ -476,7 +476,7 @@ class AnalysisMixin:
             >>> # Train or load tuned lens
             >>> tuned_lens = model.train_tuned_lens(texts, num_steps=250)
             >>> # Or load pre-trained:
-            >>> # tuned_lens = TunedLens.load("tuned_lens.safetensors")
+            >>> # tuned_lens = TunedLens.load("tuned_lens")  # Loads .npz and .json files
             >>>
             >>> # Apply tuned lens
             >>> results = model.tuned_logit_lens(
@@ -504,6 +504,12 @@ class AnalysisMixin:
 
         # Get final layer norm
         final_norm_layer = self._module_resolver.get_final_norm()
+        if final_norm_layer is None:
+            warnings.warn(
+                "Cannot find final layer norm for tuned lens. Tried paths:\n"
+                f"  {self._module_resolver.NORM_PATHS}\n"
+                "Proceeding without normalization. This may affect prediction quality."
+            )
 
         # Determine which layers to analyze
         if layers is None:

--- a/mlxterp/model.py
+++ b/mlxterp/model.py
@@ -317,7 +317,6 @@ class InterpretableModel(TokenizerMixin, AnalysisMixin, SAEMixin):
         learning_rate: float = 1.0,
         momentum: float = 0.9,
         max_seq_len: int = 2048,
-        batch_size: int = 1,
         gradient_clip: float = 1.0,
         save_path: Optional[str] = None,
         verbose: bool = True,
@@ -331,15 +330,19 @@ class InterpretableModel(TokenizerMixin, AnalysisMixin, SAEMixin):
         mismatches, producing more accurate intermediate predictions than
         the standard logit lens.
 
+        Note:
+            Training processes one sequence chunk at a time (no batching).
+            This follows the paper's approach where each training step uses
+            a single sequence of up to max_seq_len tokens.
+
         Args:
             dataset: List of text strings for training
             num_steps: Number of training steps (default: 250)
             learning_rate: Initial learning rate (default: 1.0)
             momentum: Nesterov momentum coefficient (default: 0.9)
             max_seq_len: Maximum sequence length for training chunks (default: 2048)
-            batch_size: Batch size (default: 1)
             gradient_clip: Gradient clipping norm (default: 1.0)
-            save_path: Optional path to save trained weights
+            save_path: Optional path to save trained weights (creates .npz and .json files)
             verbose: If True, print training progress
             callback: Optional callback function called with (step, loss) after each step
 
@@ -352,7 +355,7 @@ class InterpretableModel(TokenizerMixin, AnalysisMixin, SAEMixin):
             >>> tuned_lens = model.train_tuned_lens(
             ...     texts,
             ...     num_steps=250,
-            ...     save_path="tuned_lens_llama.safetensors"
+            ...     save_path="tuned_lens_llama"  # Creates .npz and .json files
             ... )
             >>> # Use with tuned_logit_lens
             >>> results = model.tuned_logit_lens("Hello world", tuned_lens)
@@ -369,7 +372,6 @@ class InterpretableModel(TokenizerMixin, AnalysisMixin, SAEMixin):
             learning_rate=learning_rate,
             momentum=momentum,
             max_seq_len=max_seq_len,
-            batch_size=batch_size,
             gradient_clip=gradient_clip,
             save_path=save_path,
             verbose=verbose,
@@ -381,14 +383,14 @@ class InterpretableModel(TokenizerMixin, AnalysisMixin, SAEMixin):
         Load a pre-trained tuned lens from a file.
 
         Args:
-            path: Path to the saved tuned lens weights (expects .safetensors and .json files)
+            path: Path to the saved tuned lens weights (expects .npz and .json files)
 
         Returns:
             Loaded TunedLens instance
 
         Example:
             >>> model = InterpretableModel("mlx-community/Llama-3.2-1B-Instruct")
-            >>> tuned_lens = model.load_tuned_lens("tuned_lens_llama.safetensors")
+            >>> tuned_lens = model.load_tuned_lens("tuned_lens_llama")  # Loads .npz and .json
             >>> results = model.tuned_logit_lens("Hello world", tuned_lens)
         """
         from .tuned_lens import TunedLens

--- a/mlxterp/model.py
+++ b/mlxterp/model.py
@@ -357,8 +357,8 @@ class InterpretableModel(TokenizerMixin, AnalysisMixin, SAEMixin):
             ...     num_steps=250,
             ...     save_path="tuned_lens_llama"  # Creates .npz and .json files
             ... )
-            >>> # Use with tuned_logit_lens
-            >>> results = model.tuned_logit_lens("Hello world", tuned_lens)
+            >>> # Use with tuned_lens
+            >>> results = model.tuned_lens("Hello world", tuned_lens)
 
         Reference:
             Belrose et al., "Eliciting Latent Predictions from Transformers with the Tuned Lens"
@@ -391,7 +391,7 @@ class InterpretableModel(TokenizerMixin, AnalysisMixin, SAEMixin):
         Example:
             >>> model = InterpretableModel("mlx-community/Llama-3.2-1B-Instruct")
             >>> tuned_lens = model.load_tuned_lens("tuned_lens_llama")  # Loads .npz and .json
-            >>> results = model.tuned_logit_lens("Hello world", tuned_lens)
+            >>> results = model.tuned_lens("Hello world", tuned_lens)
         """
         from .tuned_lens import TunedLens
         return TunedLens.load(path)

--- a/mlxterp/model.py
+++ b/mlxterp/model.py
@@ -310,6 +310,90 @@ class InterpretableModel(TokenizerMixin, AnalysisMixin, SAEMixin):
             # Not in trace context - return placeholder
             return OutputProxy(value=None, name="__model_output__")
 
+    def train_tuned_lens(
+        self,
+        dataset: List[str],
+        num_steps: int = 250,
+        learning_rate: float = 1.0,
+        momentum: float = 0.9,
+        max_seq_len: int = 2048,
+        batch_size: int = 1,
+        gradient_clip: float = 1.0,
+        save_path: Optional[str] = None,
+        verbose: bool = True,
+        callback: Optional[Callable[[int, float], None]] = None,
+    ) -> Any:
+        """
+        Train a tuned lens for this model.
+
+        The tuned lens technique (Belrose et al., 2023) trains small affine
+        transformations for each layer to correct for coordinate system
+        mismatches, producing more accurate intermediate predictions than
+        the standard logit lens.
+
+        Args:
+            dataset: List of text strings for training
+            num_steps: Number of training steps (default: 250)
+            learning_rate: Initial learning rate (default: 1.0)
+            momentum: Nesterov momentum coefficient (default: 0.9)
+            max_seq_len: Maximum sequence length for training chunks (default: 2048)
+            batch_size: Batch size (default: 1)
+            gradient_clip: Gradient clipping norm (default: 1.0)
+            save_path: Optional path to save trained weights
+            verbose: If True, print training progress
+            callback: Optional callback function called with (step, loss) after each step
+
+        Returns:
+            Trained TunedLens instance
+
+        Example:
+            >>> model = InterpretableModel("mlx-community/Llama-3.2-1B-Instruct")
+            >>> texts = ["Sample text 1", "Sample text 2", ...]
+            >>> tuned_lens = model.train_tuned_lens(
+            ...     texts,
+            ...     num_steps=250,
+            ...     save_path="tuned_lens_llama.safetensors"
+            ... )
+            >>> # Use with tuned_logit_lens
+            >>> results = model.tuned_logit_lens("Hello world", tuned_lens)
+
+        Reference:
+            Belrose et al., "Eliciting Latent Predictions from Transformers with the Tuned Lens"
+            https://arxiv.org/abs/2303.08112
+        """
+        from .tuned_lens import train_tuned_lens
+        return train_tuned_lens(
+            self,
+            dataset=dataset,
+            num_steps=num_steps,
+            learning_rate=learning_rate,
+            momentum=momentum,
+            max_seq_len=max_seq_len,
+            batch_size=batch_size,
+            gradient_clip=gradient_clip,
+            save_path=save_path,
+            verbose=verbose,
+            callback=callback,
+        )
+
+    def load_tuned_lens(self, path: str) -> Any:
+        """
+        Load a pre-trained tuned lens from a file.
+
+        Args:
+            path: Path to the saved tuned lens weights (expects .safetensors and .json files)
+
+        Returns:
+            Loaded TunedLens instance
+
+        Example:
+            >>> model = InterpretableModel("mlx-community/Llama-3.2-1B-Instruct")
+            >>> tuned_lens = model.load_tuned_lens("tuned_lens_llama.safetensors")
+            >>> results = model.tuned_logit_lens("Hello world", tuned_lens)
+        """
+        from .tuned_lens import TunedLens
+        return TunedLens.load(path)
+
     def __repr__(self):
         """String representation of the model"""
         model_type = type(self.model).__name__

--- a/mlxterp/tuned_lens.py
+++ b/mlxterp/tuned_lens.py
@@ -1,0 +1,442 @@
+"""
+Tuned Lens implementation for improved layer-wise predictions.
+
+The tuned lens technique (Belrose et al., 2023) trains small affine transformations
+for each layer to correct for coordinate system mismatches between layers, producing
+more accurate intermediate predictions than the standard logit lens.
+
+Reference:
+    Belrose et al., "Eliciting Latent Predictions from Transformers with the Tuned Lens"
+    https://arxiv.org/abs/2303.08112
+"""
+
+import mlx.core as mx
+import mlx.nn as nn
+from typing import Optional, List, Dict, Any, Callable
+from pathlib import Path
+import json
+
+
+def log_softmax(x: mx.array, axis: int = -1) -> mx.array:
+    """
+    Compute log softmax.
+
+    MLX doesn't have a built-in log_softmax, so we compute it as:
+    log_softmax(x) = x - logsumexp(x)
+
+    Args:
+        x: Input array
+        axis: Axis along which to compute log softmax
+
+    Returns:
+        Log softmax of x
+    """
+    return x - mx.logsumexp(x, axis=axis, keepdims=True)
+
+
+class TunedLens(nn.Module):
+    """
+    Learned affine translators for each layer.
+
+    The tuned lens uses layer-specific affine transformations (Wx + b) to map
+    hidden states from each layer into a space where the final output projection
+    can make accurate predictions. This corrects for coordinate system mismatches
+    between layers.
+
+    Attributes:
+        num_layers: Number of transformer layers
+        hidden_dim: Dimension of hidden states
+        translators: List of linear layers, one per transformer layer
+
+    Example:
+        >>> # Create tuned lens for a model
+        >>> tuned_lens = TunedLens(num_layers=32, hidden_dim=4096)
+        >>>
+        >>> # Apply to a hidden state from layer 10
+        >>> translated = tuned_lens(hidden_state, layer_idx=10)
+        >>>
+        >>> # Save and load
+        >>> tuned_lens.save("tuned_lens_llama.safetensors")
+        >>> loaded = TunedLens.load("tuned_lens_llama.safetensors")
+    """
+
+    def __init__(self, num_layers: int, hidden_dim: int):
+        """
+        Initialize tuned lens with identity-initialized translators.
+
+        Args:
+            num_layers: Number of transformer layers in the model
+            hidden_dim: Dimension of hidden states
+        """
+        super().__init__()
+        self.num_layers = num_layers
+        self.hidden_dim = hidden_dim
+
+        # Create translators for each layer, initialized close to identity
+        self.translators = []
+        for i in range(num_layers):
+            translator = nn.Linear(hidden_dim, hidden_dim)
+            self.translators.append(translator)
+
+        # Initialize close to identity for stability
+        self._init_identity()
+
+    def _init_identity(self):
+        """Initialize translators close to identity transformation."""
+        for translator in self.translators:
+            # Set weight to identity matrix
+            translator.weight = mx.eye(self.hidden_dim)
+            # Set bias to zeros
+            translator.bias = mx.zeros((self.hidden_dim,))
+
+    def __call__(self, h: mx.array, layer_idx: int) -> mx.array:
+        """
+        Apply the translator for a specific layer.
+
+        Args:
+            h: Hidden state tensor, shape (hidden_dim,) or (batch, seq_len, hidden_dim)
+            layer_idx: Index of the layer this hidden state came from
+
+        Returns:
+            Translated hidden state with same shape as input
+        """
+        if layer_idx < 0 or layer_idx >= self.num_layers:
+            raise ValueError(
+                f"layer_idx {layer_idx} out of range [0, {self.num_layers})"
+            )
+        return self.translators[layer_idx](h)
+
+    def save(self, path: str) -> None:
+        """
+        Save tuned lens weights and config to a file.
+
+        Args:
+            path: Path to save the weights (will create .npz and .json files)
+        """
+        path = Path(path)
+
+        # Save config
+        config = {
+            "num_layers": self.num_layers,
+            "hidden_dim": self.hidden_dim,
+        }
+        config_path = path.with_suffix(".json")
+        with open(config_path, "w") as f:
+            json.dump(config, f, indent=2)
+
+        # Save weights using mx.savez
+        weights_path = path.with_suffix(".npz")
+        weights = {}
+        for i, translator in enumerate(self.translators):
+            weights[f"translators_{i}_weight"] = translator.weight
+            weights[f"translators_{i}_bias"] = translator.bias
+        mx.savez(str(weights_path), **weights)
+
+    @classmethod
+    def load(cls, path: str) -> "TunedLens":
+        """
+        Load tuned lens from saved files.
+
+        Args:
+            path: Path to the saved weights (expects .npz and .json files)
+
+        Returns:
+            Loaded TunedLens instance
+        """
+        path = Path(path)
+
+        # Load config
+        config_path = path.with_suffix(".json")
+        with open(config_path, "r") as f:
+            config = json.load(f)
+
+        # Create instance
+        instance = cls(
+            num_layers=config["num_layers"],
+            hidden_dim=config["hidden_dim"],
+        )
+
+        # Load weights
+        weights_path = path.with_suffix(".npz")
+        weights = mx.load(str(weights_path))
+
+        for i in range(instance.num_layers):
+            instance.translators[i].weight = weights[f"translators_{i}_weight"]
+            instance.translators[i].bias = weights[f"translators_{i}_bias"]
+
+        return instance
+
+
+def kl_divergence(log_p: mx.array, log_q: mx.array) -> mx.array:
+    """
+    Compute KL divergence KL(p || q) from log probabilities.
+
+    Args:
+        log_p: Log probabilities of target distribution (from final layer)
+        log_q: Log probabilities of predicted distribution (from tuned lens)
+
+    Returns:
+        KL divergence (scalar)
+    """
+    p = mx.exp(log_p)
+    return mx.sum(p * (log_p - log_q), axis=-1).mean()
+
+
+def train_tuned_lens(
+    model: Any,
+    dataset: List[str],
+    num_steps: int = 250,
+    learning_rate: float = 1.0,
+    momentum: float = 0.9,
+    max_seq_len: int = 2048,
+    batch_size: int = 1,
+    gradient_clip: float = 1.0,
+    save_path: Optional[str] = None,
+    verbose: bool = True,
+    callback: Optional[Callable[[int, float], None]] = None,
+) -> TunedLens:
+    """
+    Train tuned lens translators using KL divergence loss.
+
+    The training minimizes KL divergence between:
+    - Target: Model's final output distribution
+    - Prediction: Tuned lens prediction from each intermediate layer
+
+    Training follows the paper's recommendations:
+    - SGD with Nesterov momentum (0.9)
+    - Learning rate 1.0 with linear decay over training steps
+    - Gradient clipping with norm 1.0
+
+    Args:
+        model: InterpretableModel instance with loaded model
+        dataset: List of text strings for training
+        num_steps: Number of training steps (default: 250)
+        learning_rate: Initial learning rate (default: 1.0)
+        momentum: Nesterov momentum coefficient (default: 0.9)
+        max_seq_len: Maximum sequence length for training chunks (default: 2048)
+        batch_size: Batch size (default: 1)
+        gradient_clip: Gradient clipping norm (default: 1.0)
+        save_path: Optional path to save trained weights
+        verbose: If True, print training progress
+        callback: Optional callback function called with (step, loss) after each step
+
+    Returns:
+        Trained TunedLens instance
+
+    Example:
+        >>> model = InterpretableModel("mlx-community/Llama-3.2-1B-Instruct")
+        >>> texts = ["Sample text 1", "Sample text 2", ...]
+        >>> tuned_lens = train_tuned_lens(
+        ...     model, texts,
+        ...     num_steps=250,
+        ...     save_path="tuned_lens.safetensors"
+        ... )
+    """
+    import mlx.optimizers as optim
+    from .core.module_resolver import find_layer_key_pattern
+
+    # Get model dimensions
+    num_layers = len(model.layers)
+
+    # Get hidden dimension from model
+    # Try to infer from first layer's weight matrix or embedding
+    try:
+        # Try to get from embedding layer
+        embed_layer = model._module_resolver.get_embedding_layer()
+        if hasattr(embed_layer, "weight"):
+            hidden_dim = embed_layer.weight.shape[1]
+        elif hasattr(embed_layer, "scales"):
+            # Quantized embedding
+            hidden_dim = embed_layer.scales.shape[0]
+        else:
+            # Fallback: try to get from a trace
+            sample_tokens = model.encode(dataset[0][:100])
+            with model.trace(mx.array([sample_tokens[:10]])) as trace:
+                pass
+            # Get dimension from first layer output
+            layer_key = find_layer_key_pattern(trace.activations, 0)
+            if layer_key:
+                hidden_dim = trace.activations[layer_key].shape[-1]
+            else:
+                raise ValueError("Could not determine hidden dimension from model")
+    except Exception as e:
+        raise ValueError(f"Could not determine model hidden dimension: {e}")
+
+    # Create tuned lens
+    tuned_lens = TunedLens(num_layers=num_layers, hidden_dim=hidden_dim)
+
+    # Get final layer norm and output projection
+    final_norm = model._module_resolver.get_final_norm()
+    proj_module, proj_path, is_weight_tied = model._module_resolver.get_output_projection()
+
+    if proj_module is None:
+        raise ValueError("Could not find output projection (lm_head or embedding) in model")
+
+    # Create optimizer with Nesterov momentum
+    optimizer = optim.SGD(learning_rate=learning_rate, momentum=momentum, nesterov=True)
+
+    # Build a single large text from dataset for chunking
+    all_text = " ".join(dataset)
+    all_tokens = model.encode(all_text)
+
+    if len(all_tokens) < max_seq_len:
+        raise ValueError(
+            f"Dataset too small: {len(all_tokens)} tokens, need at least {max_seq_len}. "
+            "Provide more text data."
+        )
+
+    # Training loop
+    step = 0
+    text_position = 0
+
+    if verbose:
+        print(f"Training tuned lens: {num_layers} layers, {hidden_dim} hidden dim")
+        print(f"Dataset: {len(all_tokens)} tokens, {num_steps} steps")
+
+    # Define loss function
+    def compute_loss(tuned_lens_params, input_tokens, layer_activations, target_logits):
+        """Compute KL divergence loss for all layers."""
+        # Update tuned lens with current params
+        tuned_lens.update(tuned_lens_params)
+
+        total_loss = mx.array(0.0)
+        seq_len = input_tokens.shape[1]
+
+        for layer_idx in range(num_layers):
+            layer_key = find_layer_key_pattern(layer_activations, layer_idx)
+            if layer_key is None:
+                continue
+
+            layer_output = layer_activations[layer_key]  # (batch, seq_len, hidden_dim)
+
+            # Apply tuned lens translator
+            translated = tuned_lens(layer_output, layer_idx)
+
+            # Apply final norm if available
+            if final_norm is not None:
+                translated = final_norm(translated)
+
+            # Compute logits through output projection
+            if is_weight_tied:
+                # Weight-tied: use embedding weights transposed
+                if hasattr(proj_module, "scales"):
+                    # Quantized
+                    embed_weights = mx.dequantize(
+                        proj_module.weight,
+                        proj_module.scales,
+                        proj_module.biases,
+                        proj_module.group_size,
+                        proj_module.bits,
+                    )
+                else:
+                    embed_weights = proj_module.weight
+                pred_logits = translated @ embed_weights.T
+            else:
+                pred_logits = proj_module(translated)
+
+            # Compute log probabilities
+            pred_log_probs = log_softmax(pred_logits, axis=-1)
+            target_log_probs = log_softmax(target_logits, axis=-1)
+
+            # KL divergence loss
+            layer_loss = kl_divergence(target_log_probs, pred_log_probs)
+            total_loss = total_loss + layer_loss
+
+        return total_loss / num_layers
+
+    # Training iterations
+    while step < num_steps:
+        # Get next chunk of tokens
+        end_pos = min(text_position + max_seq_len, len(all_tokens))
+        chunk_tokens = all_tokens[text_position:end_pos]
+
+        if len(chunk_tokens) < 10:
+            # Wrap around if we've reached the end
+            text_position = 0
+            continue
+
+        input_tokens = mx.array([chunk_tokens])
+
+        # Run forward pass to get activations and target logits
+        with model.trace(input_tokens) as trace:
+            pass
+
+        # Get target logits from final output
+        # We need to get the model's actual output logits
+        try:
+            # Run model directly to get final logits
+            if hasattr(model.model, '__call__'):
+                target_logits = model.model(input_tokens)
+                if isinstance(target_logits, tuple):
+                    target_logits = target_logits[0]
+            else:
+                # Fallback: compute from last layer
+                last_layer_key = find_layer_key_pattern(trace.activations, num_layers - 1)
+                if last_layer_key:
+                    last_hidden = trace.activations[last_layer_key]
+                    if final_norm is not None:
+                        last_hidden = final_norm(last_hidden)
+                    if is_weight_tied:
+                        if hasattr(proj_module, "scales"):
+                            embed_weights = mx.dequantize(
+                                proj_module.weight,
+                                proj_module.scales,
+                                proj_module.biases,
+                                proj_module.group_size,
+                                proj_module.bits,
+                            )
+                        else:
+                            embed_weights = proj_module.weight
+                        target_logits = last_hidden @ embed_weights.T
+                    else:
+                        target_logits = proj_module(last_hidden)
+                else:
+                    raise ValueError("Could not get target logits")
+        except Exception as e:
+            raise ValueError(f"Error computing target logits: {e}")
+
+        # Compute loss and gradients
+        loss_fn = lambda params: compute_loss(
+            params, input_tokens, trace.activations, target_logits
+        )
+        loss, grads = mx.value_and_grad(loss_fn)(tuned_lens.parameters())
+
+        # Gradient clipping
+        grad_norm = mx.sqrt(sum(mx.sum(g * g) for g in mx.utils.tree_flatten(grads)[0]))
+        if grad_norm > gradient_clip:
+            scale = gradient_clip / (grad_norm + 1e-6)
+            grads = mx.utils.tree_map(lambda g: g * scale, grads)
+
+        # Linear learning rate decay
+        current_lr = learning_rate * (1 - step / num_steps)
+        optimizer.learning_rate = current_lr
+
+        # Update parameters
+        optimizer.update(tuned_lens, grads)
+        mx.eval(tuned_lens.parameters())
+
+        loss_val = float(loss)
+
+        if verbose and step % 10 == 0:
+            print(f"Step {step}/{num_steps}, Loss: {loss_val:.4f}, LR: {current_lr:.4f}")
+
+        if callback is not None:
+            callback(step, loss_val)
+
+        step += 1
+        text_position = end_pos
+
+        # Wrap around if needed
+        if text_position >= len(all_tokens) - max_seq_len:
+            text_position = 0
+
+    if verbose:
+        print(f"Training complete. Final loss: {loss_val:.4f}")
+
+    # Save if path provided
+    if save_path:
+        tuned_lens.save(save_path)
+        if verbose:
+            print(f"Saved tuned lens to {save_path}")
+
+    return tuned_lens

--- a/tests/test_tuned_lens.py
+++ b/tests/test_tuned_lens.py
@@ -473,7 +473,7 @@ class TestTrainTunedLens:
         tuned_lens = train_tuned_lens(
             model,
             dataset,
-            num_steps=10,  # More steps to ensure weight changes
+            num_steps=50,  # More steps to ensure weight changes
             max_seq_len=50,
             learning_rate=1.0,
             verbose=False,

--- a/tests/test_tuned_lens.py
+++ b/tests/test_tuned_lens.py
@@ -1,0 +1,433 @@
+"""
+Unit and integration tests for the Tuned Lens implementation.
+
+Tests cover:
+- TunedLens class initialization and forward pass
+- Identity initialization behavior
+- Save/load functionality
+- Integration with InterpretableModel
+- tuned_logit_lens method
+"""
+
+import pytest
+import mlx.core as mx
+import mlx.nn as nn
+import tempfile
+from pathlib import Path
+
+from mlxterp import InterpretableModel, TunedLens
+from mlxterp.tuned_lens import train_tuned_lens, kl_divergence
+
+
+# ============================================================================
+# Mock Models for Testing
+# ============================================================================
+
+class MockTransformerBlock(nn.Module):
+    """A simple transformer block for testing."""
+    def __init__(self, dim=64):
+        super().__init__()
+        self.self_attn = MockAttention(dim)
+        self.mlp = nn.Linear(dim, dim)
+
+    def __call__(self, x):
+        x = x + self.self_attn(x)
+        x = x + self.mlp(x)
+        return x
+
+
+class MockAttention(nn.Module):
+    """Mock attention for testing."""
+    def __init__(self, dim=64):
+        super().__init__()
+        self.q_proj = nn.Linear(dim, dim)
+        self.k_proj = nn.Linear(dim, dim)
+        self.v_proj = nn.Linear(dim, dim)
+        self.o_proj = nn.Linear(dim, dim)
+
+    def __call__(self, x):
+        return self.o_proj(x)
+
+
+class MockModel(nn.Module):
+    """Mock model with standard structure."""
+    def __init__(self, vocab_size=1000, dim=64, n_layers=4):
+        super().__init__()
+        self.embed_tokens = nn.Embedding(vocab_size, dim)
+        self.norm = nn.RMSNorm(dim)
+        self.lm_head = nn.Linear(dim, vocab_size)
+        self.layers = [MockTransformerBlock(dim) for _ in range(n_layers)]
+
+    def __call__(self, x):
+        x = self.embed_tokens(x)
+        for layer in self.layers:
+            x = layer(x)
+        x = self.norm(x)
+        return self.lm_head(x)
+
+
+class MockTokenizer:
+    """Simple mock tokenizer for testing."""
+    def __init__(self, vocab_size=1000):
+        self.vocab_size = vocab_size
+
+    def encode(self, text, **kwargs):
+        if isinstance(text, mx.array):
+            return text.tolist() if text.ndim == 1 else text[0].tolist()
+        return list(range(len(text.split()) + 1))
+
+    def decode(self, ids, **kwargs):
+        return " ".join([f"token_{i}" for i in ids])
+
+
+# ============================================================================
+# TunedLens Class Tests
+# ============================================================================
+
+class TestTunedLensInit:
+    """Test TunedLens initialization."""
+
+    def test_basic_init(self):
+        """Test basic initialization."""
+        tuned_lens = TunedLens(num_layers=4, hidden_dim=64)
+
+        assert tuned_lens.num_layers == 4
+        assert tuned_lens.hidden_dim == 64
+        assert len(tuned_lens.translators) == 4
+
+    def test_translator_structure(self):
+        """Test that translators are linear layers."""
+        tuned_lens = TunedLens(num_layers=4, hidden_dim=64)
+
+        for translator in tuned_lens.translators:
+            assert isinstance(translator, nn.Linear)
+            assert translator.weight.shape == (64, 64)
+            assert translator.bias.shape == (64,)
+
+    def test_identity_initialization(self):
+        """Test that translators are initialized close to identity."""
+        tuned_lens = TunedLens(num_layers=4, hidden_dim=64)
+
+        for translator in tuned_lens.translators:
+            # Weight should be identity matrix
+            expected_weight = mx.eye(64)
+            assert mx.allclose(translator.weight, expected_weight).item()
+
+            # Bias should be zeros
+            expected_bias = mx.zeros((64,))
+            assert mx.allclose(translator.bias, expected_bias).item()
+
+
+class TestTunedLensForward:
+    """Test TunedLens forward pass."""
+
+    @pytest.fixture
+    def tuned_lens(self):
+        return TunedLens(num_layers=4, hidden_dim=64)
+
+    def test_forward_1d(self, tuned_lens):
+        """Test forward pass with 1D input."""
+        hidden = mx.random.normal((64,))
+
+        output = tuned_lens(hidden, layer_idx=0)
+        assert output.shape == (64,)
+
+    def test_forward_3d(self, tuned_lens):
+        """Test forward pass with 3D input (batch, seq_len, hidden)."""
+        hidden = mx.random.normal((2, 10, 64))
+
+        output = tuned_lens(hidden, layer_idx=0)
+        assert output.shape == (2, 10, 64)
+
+    def test_identity_pass_through(self, tuned_lens):
+        """Test that identity-initialized translator passes input through."""
+        hidden = mx.random.normal((64,))
+
+        output = tuned_lens(hidden, layer_idx=0)
+
+        # Should be approximately equal due to identity initialization
+        assert mx.allclose(hidden, output, atol=1e-5).item()
+
+    def test_different_layers(self, tuned_lens):
+        """Test that different layers can have different translations."""
+        # Modify one translator
+        tuned_lens.translators[1].weight = mx.eye(64) * 2.0
+
+        hidden = mx.random.normal((64,))
+
+        output_0 = tuned_lens(hidden, layer_idx=0)
+        output_1 = tuned_lens(hidden, layer_idx=1)
+
+        # Should not be equal
+        assert not mx.allclose(output_0, output_1).item()
+
+    def test_invalid_layer_idx(self, tuned_lens):
+        """Test that invalid layer index raises error."""
+        hidden = mx.random.normal((64,))
+
+        with pytest.raises(ValueError):
+            tuned_lens(hidden, layer_idx=10)
+
+        with pytest.raises(ValueError):
+            tuned_lens(hidden, layer_idx=-1)
+
+
+class TestTunedLensSaveLoad:
+    """Test TunedLens save/load functionality."""
+
+    def test_save_and_load(self):
+        """Test saving and loading tuned lens."""
+        tuned_lens = TunedLens(num_layers=4, hidden_dim=64)
+
+        # Modify some weights to verify they're saved/loaded correctly
+        tuned_lens.translators[0].weight = mx.eye(64) * 2.0
+        tuned_lens.translators[0].bias = mx.ones((64,))
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            save_path = Path(tmpdir) / "test_tuned_lens"
+
+            # Save
+            tuned_lens.save(str(save_path))
+
+            # Verify files exist
+            assert (save_path.with_suffix(".npz")).exists()
+            assert (save_path.with_suffix(".json")).exists()
+
+            # Load
+            loaded = TunedLens.load(str(save_path))
+
+            # Verify structure
+            assert loaded.num_layers == 4
+            assert loaded.hidden_dim == 64
+
+            # Verify weights
+            assert mx.allclose(
+                loaded.translators[0].weight,
+                mx.eye(64) * 2.0
+            ).item()
+            assert mx.allclose(
+                loaded.translators[0].bias,
+                mx.ones((64,))
+            ).item()
+
+    def test_load_preserves_functionality(self):
+        """Test that loaded model works correctly."""
+        tuned_lens = TunedLens(num_layers=4, hidden_dim=64)
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            save_path = Path(tmpdir) / "test_tuned_lens"
+            tuned_lens.save(str(save_path))
+            loaded = TunedLens.load(str(save_path))
+
+            # Test forward pass
+            hidden = mx.random.normal((64,))
+            original_output = tuned_lens(hidden, layer_idx=0)
+            loaded_output = loaded(hidden, layer_idx=0)
+
+            assert mx.allclose(original_output, loaded_output).item()
+
+
+# ============================================================================
+# KL Divergence Tests
+# ============================================================================
+
+def log_softmax(x, axis=-1):
+    """Compute log softmax (MLX doesn't have this built-in)."""
+    return x - mx.logsumexp(x, axis=axis, keepdims=True)
+
+
+class TestKLDivergence:
+    """Test KL divergence computation."""
+
+    def test_kl_same_distribution(self):
+        """KL divergence of same distribution should be 0."""
+        log_p = log_softmax(mx.random.normal((10,)), axis=-1)
+
+        kl = kl_divergence(log_p, log_p)
+        assert mx.abs(kl).item() < 1e-5
+
+    def test_kl_different_distributions(self):
+        """KL divergence of different distributions should be positive."""
+        log_p = log_softmax(mx.random.normal((10,)), axis=-1)
+        log_q = log_softmax(mx.random.normal((10,)), axis=-1)
+
+        kl = kl_divergence(log_p, log_q)
+        assert kl.item() >= 0
+
+    def test_kl_batched(self):
+        """Test KL divergence with batched input."""
+        log_p = log_softmax(mx.random.normal((5, 10)), axis=-1)
+        log_q = log_softmax(mx.random.normal((5, 10)), axis=-1)
+
+        kl = kl_divergence(log_p, log_q)
+        assert kl.shape == ()  # Should be scalar
+
+
+# ============================================================================
+# Integration Tests with InterpretableModel
+# ============================================================================
+
+class TestTunedLensIntegration:
+    """Test TunedLens integration with InterpretableModel."""
+
+    @pytest.fixture
+    def model(self):
+        base = MockModel(vocab_size=100, dim=32, n_layers=4)
+        tokenizer = MockTokenizer(vocab_size=100)
+        return InterpretableModel(base, tokenizer=tokenizer)
+
+    def test_tuned_logit_lens_basic(self, model):
+        """Test basic tuned_logit_lens call."""
+        tuned_lens = TunedLens(num_layers=4, hidden_dim=32)
+        input_tokens = mx.array([[1, 2, 3]])
+
+        results = model.tuned_logit_lens(input_tokens, tuned_lens, layers=[0, 1])
+
+        # Check structure
+        assert isinstance(results, dict)
+        assert len(results) > 0
+
+        for layer_idx, layer_results in results.items():
+            assert isinstance(layer_results, list)
+            for pos_results in layer_results:
+                assert isinstance(pos_results, list)
+                for pred in pos_results:
+                    assert len(pred) == 3  # (token_id, score, token_str)
+
+    def test_tuned_logit_lens_specific_layers(self, model):
+        """Test tuned_logit_lens with specific layers."""
+        tuned_lens = TunedLens(num_layers=4, hidden_dim=32)
+        input_tokens = mx.array([[1, 2, 3]])
+
+        results = model.tuned_logit_lens(input_tokens, tuned_lens, layers=[0, 2])
+
+        assert set(results.keys()).issubset({0, 2})
+
+    def test_tuned_logit_lens_position(self, model):
+        """Test tuned_logit_lens with position parameter."""
+        tuned_lens = TunedLens(num_layers=4, hidden_dim=32)
+        input_tokens = mx.array([[1, 2, 3, 4, 5]])
+
+        # All positions
+        results_all = model.tuned_logit_lens(input_tokens, tuned_lens, layers=[0])
+        # Last position only
+        results_last = model.tuned_logit_lens(input_tokens, tuned_lens, layers=[0], position=-1)
+
+        assert len(results_all[0]) == 5
+        assert len(results_last[0]) == 1
+
+    def test_tuned_logit_lens_top_k(self, model):
+        """Test tuned_logit_lens top_k parameter."""
+        tuned_lens = TunedLens(num_layers=4, hidden_dim=32)
+        input_tokens = mx.array([[1, 2, 3]])
+
+        results_1 = model.tuned_logit_lens(input_tokens, tuned_lens, layers=[0], top_k=1)
+        results_5 = model.tuned_logit_lens(input_tokens, tuned_lens, layers=[0], top_k=5)
+
+        for pos_preds in results_1[0]:
+            assert len(pos_preds) == 1
+        for pos_preds in results_5[0]:
+            assert len(pos_preds) == 5
+
+
+class TestTunedLensModelMethods:
+    """Test InterpretableModel tuned lens methods."""
+
+    @pytest.fixture
+    def model(self):
+        base = MockModel(vocab_size=100, dim=32, n_layers=4)
+        tokenizer = MockTokenizer(vocab_size=100)
+        return InterpretableModel(base, tokenizer=tokenizer)
+
+    def test_load_tuned_lens_method(self, model):
+        """Test model.load_tuned_lens method."""
+        # Create and save a tuned lens
+        tuned_lens = TunedLens(num_layers=4, hidden_dim=32)
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            save_path = Path(tmpdir) / "test_tuned_lens"
+            tuned_lens.save(str(save_path))
+
+            # Load via model method
+            loaded = model.load_tuned_lens(str(save_path))
+
+            assert loaded.num_layers == 4
+            assert loaded.hidden_dim == 32
+
+
+class TestTunedLensCompareLogitLens:
+    """Compare tuned lens with regular logit lens."""
+
+    @pytest.fixture
+    def model(self):
+        base = MockModel(vocab_size=100, dim=32, n_layers=4)
+        tokenizer = MockTokenizer(vocab_size=100)
+        return InterpretableModel(base, tokenizer=tokenizer)
+
+    def test_identical_with_identity(self, model):
+        """With identity initialization, tuned lens should match logit lens."""
+        tuned_lens = TunedLens(num_layers=4, hidden_dim=32)
+        input_tokens = mx.array([[1, 2, 3]])
+
+        # Get both results
+        regular = model.logit_lens(input_tokens, layers=[0, 1, 2, 3])
+        tuned = model.tuned_logit_lens(input_tokens, tuned_lens, layers=[0, 1, 2, 3])
+
+        # With identity initialization, predictions should be very similar
+        for layer_idx in regular.keys():
+            if layer_idx in tuned:
+                for pos_idx in range(len(regular[layer_idx])):
+                    reg_top = regular[layer_idx][pos_idx][0][0]  # Top token ID
+                    tuned_top = tuned[layer_idx][pos_idx][0][0]  # Top token ID
+                    # May not be exactly equal due to floating point, but should be similar
+                    # We check that at least one matches in top-5
+                    reg_tokens = set(p[0] for p in regular[layer_idx][pos_idx][:5])
+                    assert tuned_top in reg_tokens or reg_top in tuned.get(layer_idx, [[]])[pos_idx][:5]
+
+
+class TestTunedLensEdgeCases:
+    """Test edge cases and error handling."""
+
+    def test_mismatched_dimensions(self):
+        """Test error handling for mismatched dimensions."""
+        tuned_lens = TunedLens(num_layers=4, hidden_dim=64)
+
+        # Wrong hidden dimension
+        hidden = mx.random.normal((32,))  # Should be 64
+
+        with pytest.raises(Exception):  # Could be various error types
+            tuned_lens(hidden, layer_idx=0)
+
+    def test_empty_layers_list(self):
+        """Test with empty layers list."""
+        base = MockModel(vocab_size=100, dim=32, n_layers=4)
+        tokenizer = MockTokenizer(vocab_size=100)
+        model = InterpretableModel(base, tokenizer=tokenizer)
+        tuned_lens = TunedLens(num_layers=4, hidden_dim=32)
+        input_tokens = mx.array([[1, 2, 3]])
+
+        results = model.tuned_logit_lens(input_tokens, tuned_lens, layers=[])
+
+        assert results == {}
+
+
+# ============================================================================
+# Export Tests
+# ============================================================================
+
+class TestExports:
+    """Test that all expected classes are exported."""
+
+    def test_tuned_lens_exported(self):
+        """Test TunedLens is exported from mlxterp."""
+        from mlxterp import TunedLens
+        assert TunedLens is not None
+
+    def test_train_tuned_lens_exported(self):
+        """Test train_tuned_lens is exported from mlxterp."""
+        from mlxterp import train_tuned_lens
+        assert train_tuned_lens is not None
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/test_tuned_lens.py
+++ b/tests/test_tuned_lens.py
@@ -6,7 +6,7 @@ Tests cover:
 - Identity initialization behavior
 - Save/load functionality
 - Integration with InterpretableModel
-- tuned_logit_lens method
+- tuned_lens method
 """
 
 import pytest
@@ -276,12 +276,12 @@ class TestTunedLensIntegration:
         tokenizer = MockTokenizer(vocab_size=100)
         return InterpretableModel(base, tokenizer=tokenizer)
 
-    def test_tuned_logit_lens_basic(self, model):
-        """Test basic tuned_logit_lens call."""
+    def test_tuned_lens_basic(self, model):
+        """Test basic tuned_lens call."""
         tuned_lens = TunedLens(num_layers=4, hidden_dim=32)
         input_tokens = mx.array([[1, 2, 3]])
 
-        results = model.tuned_logit_lens(input_tokens, tuned_lens, layers=[0, 1])
+        results = model.tuned_lens(input_tokens, tuned_lens, layers=[0, 1])
 
         # Check structure
         assert isinstance(results, dict)
@@ -294,35 +294,35 @@ class TestTunedLensIntegration:
                 for pred in pos_results:
                     assert len(pred) == 3  # (token_id, score, token_str)
 
-    def test_tuned_logit_lens_specific_layers(self, model):
-        """Test tuned_logit_lens with specific layers."""
+    def test_tuned_lens_specific_layers(self, model):
+        """Test tuned_lens with specific layers."""
         tuned_lens = TunedLens(num_layers=4, hidden_dim=32)
         input_tokens = mx.array([[1, 2, 3]])
 
-        results = model.tuned_logit_lens(input_tokens, tuned_lens, layers=[0, 2])
+        results = model.tuned_lens(input_tokens, tuned_lens, layers=[0, 2])
 
         assert set(results.keys()).issubset({0, 2})
 
-    def test_tuned_logit_lens_position(self, model):
-        """Test tuned_logit_lens with position parameter."""
+    def test_tuned_lens_position(self, model):
+        """Test tuned_lens with position parameter."""
         tuned_lens = TunedLens(num_layers=4, hidden_dim=32)
         input_tokens = mx.array([[1, 2, 3, 4, 5]])
 
         # All positions
-        results_all = model.tuned_logit_lens(input_tokens, tuned_lens, layers=[0])
+        results_all = model.tuned_lens(input_tokens, tuned_lens, layers=[0])
         # Last position only
-        results_last = model.tuned_logit_lens(input_tokens, tuned_lens, layers=[0], position=-1)
+        results_last = model.tuned_lens(input_tokens, tuned_lens, layers=[0], position=-1)
 
         assert len(results_all[0]) == 5
         assert len(results_last[0]) == 1
 
-    def test_tuned_logit_lens_top_k(self, model):
-        """Test tuned_logit_lens top_k parameter."""
+    def test_tuned_lens_top_k(self, model):
+        """Test tuned_lens top_k parameter."""
         tuned_lens = TunedLens(num_layers=4, hidden_dim=32)
         input_tokens = mx.array([[1, 2, 3]])
 
-        results_1 = model.tuned_logit_lens(input_tokens, tuned_lens, layers=[0], top_k=1)
-        results_5 = model.tuned_logit_lens(input_tokens, tuned_lens, layers=[0], top_k=5)
+        results_1 = model.tuned_lens(input_tokens, tuned_lens, layers=[0], top_k=1)
+        results_5 = model.tuned_lens(input_tokens, tuned_lens, layers=[0], top_k=5)
 
         for pos_preds in results_1[0]:
             assert len(pos_preds) == 1
@@ -371,7 +371,7 @@ class TestTunedLensCompareLogitLens:
 
         # Get both results
         regular = model.logit_lens(input_tokens, layers=[0, 1, 2, 3])
-        tuned = model.tuned_logit_lens(input_tokens, tuned_lens, layers=[0, 1, 2, 3])
+        tuned = model.tuned_lens(input_tokens, tuned_lens, layers=[0, 1, 2, 3])
 
         # With identity initialization, predictions should be very similar
         for layer_idx in regular.keys():
@@ -406,7 +406,7 @@ class TestTunedLensEdgeCases:
         tuned_lens = TunedLens(num_layers=4, hidden_dim=32)
         input_tokens = mx.array([[1, 2, 3]])
 
-        results = model.tuned_logit_lens(input_tokens, tuned_lens, layers=[])
+        results = model.tuned_lens(input_tokens, tuned_lens, layers=[])
 
         assert results == {}
 


### PR DESCRIPTION
## Summary

- Implements the Tuned Lens technique from Belrose et al. (2023) for improved intermediate layer predictions
- Adds `model.tuned_lens()` method matching the paper's naming convention
- Provides `model.train_tuned_lens()` for training custom tuned lens translators
- Adds `model.load_tuned_lens()` for loading pre-trained tuned lens weights

## Key Features

**TunedLens Class:**
- Learned affine translators (Wx + b) for each layer
- Identity initialization for stable training
- Save/load functionality (.npz weights + .json config)

**Training:**
- SGD with Nesterov momentum (following paper)
- KL divergence loss between translated predictions and final output
- Linear learning rate decay
- Gradient clipping for stability

**Integration:**
- Seamless integration with existing `logit_lens()` API
- Same return format: `{layer_idx: [[pos_0_preds], [pos_1_preds], ...]}`
- Supports visualization with `plot=True`

## Changes

- `mlxterp/tuned_lens.py` - New TunedLens class and training function
- `mlxterp/analysis.py` - Add `tuned_lens()` method to AnalysisMixin
- `mlxterp/model.py` - Add `train_tuned_lens()` and `load_tuned_lens()` methods
- `mlxterp/__init__.py` - Export TunedLens and train_tuned_lens
- `docs/API.md` - Complete API documentation
- `docs/examples.md` - Usage examples
- `tests/test_tuned_lens.py` - Comprehensive test suite (30 tests)

## Test plan

- [x] All 30 tuned lens tests pass
- [x] TunedLens initialization with identity weights
- [x] Forward pass preserves dimensions
- [x] Save/load functionality
- [x] Integration with InterpretableModel
- [x] Training modifies weights
- [x] Gradient clipping works correctly

## Reference

Belrose et al., "Eliciting Latent Predictions from Transformers with the Tuned Lens" (https://arxiv.org/abs/2303.08112)

🤖 Generated with [Claude Code](https://claude.com/claude-code)