### PR TITLE
feat: causal_trace clean/corrupted comparative tracing (roadmap Tier 1 #2)

### DIFF
--- a/CAUSAL_INTERP_ROADMAP.md
+++ b/CAUSAL_INTERP_ROADMAP.md
@@ -92,11 +92,13 @@ with model.causal_trace(clean_input, corrupted_input) as ct:
 ```
 
 **Deliverables**:
-- [ ] `model.causal_trace(clean, corrupted)` context manager
-- [ ] `.patch(component)` method for declarative patching
-- [ ] `.metric(fn)` for computing causal effects inline
-- [ ] Automatic activation alignment when sequence lengths differ
-- [ ] Batch support for patching multiple components in one pass
+- [x] `model.causal_trace(clean, corrupted)` context manager — implemented as a separate `CausalTrace` class in `mlxterp/core/causal_trace.py`
+- [x] `.patch(component)` method for declarative patching — accepts short module names (`"layers.5.mlp"`) and accommodates `model.` / `model.model.` activation key prefixes automatically
+- [ ] `.metric(fn)` for computing causal effects inline — deferred; users can still invoke metrics by hand on `ct.output` and `ct.clean_output`. Built-in metrics (`logit_diff`, `kl_divergence`, `cross_entropy_diff`) live on `model.activation_patching` from Tier 1 #1
+- [x] Activation alignment when sequence lengths differ — handled by the existing `replace_with(align="end")` semantics that the patch path delegates to
+- [ ] Batch support for patching multiple components in one pass — multiple `.patch()` calls compose and the corrupted forward runs once on `.output` access; batched-input ("run k corruptions in one call") deferred
+
+Implementation: `mlxterp/core/causal_trace.py` (new file) for the `CausalTrace` class; `InterpretableModel.causal_trace()` method dispatches to it. Tests in `tests/test_causal_trace.py` (8 contract tests). Example in `examples/causal_trace.py` showing the verbose-vs-ergonomic comparison.
 
 ---
 

--- a/examples/causal_trace.py
+++ b/examples/causal_trace.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python
+"""Example: clean/corrupted comparative tracing with the causal_trace API.
+
+Demonstrates the ergonomic ``model.causal_trace`` wrapper for the
+standard activation-patching pattern. Compare to the lower-level
+two-trace pattern in ``activation_patching_example.py`` — same result,
+much less boilerplate.
+"""
+
+from __future__ import annotations
+
+from mlx_lm import load
+from mlxterp import InterpretableModel
+
+
+MODEL_NAME = "mlx-community/Llama-3.2-1B-Instruct-4bit"
+CLEAN = "Paris is the capital of France"
+CORRUPTED = "London is the capital of France"
+
+
+def main() -> None:
+    print(f"Loading {MODEL_NAME} ...")
+    base, tok = load(MODEL_NAME)
+    model = InterpretableModel(base, tokenizer=tok)
+    print(f"Model has {len(model.layers)} decoder layers.\n")
+
+    # The verbose pattern we're replacing:
+    print("# Pattern A: low-level trace + replace_with (still works)")
+    from mlxterp import interventions as iv
+    with model.trace(CLEAN) as t:
+        clean_l5 = t.activations.get("model.model.layers.5")
+
+    if clean_l5 is not None:
+        with model.trace(CORRUPTED, interventions={"layers.5": iv.replace_with(clean_l5)}):
+            print("  scheduled patch on layers.5; corrupted run ran with intervention")
+    print()
+
+    # The new ergonomic pattern:
+    print("# Pattern B: model.causal_trace (Tier 1 #2)")
+    with model.causal_trace(CLEAN, CORRUPTED) as ct:
+        ct.patch("layers.5")
+        ct.patch("layers.10.mlp")
+        print(f"  scheduled patches: {ct.patches}")
+        print(f"  clean output shape:    {ct.clean_output.shape}")
+        print(f"  patched output shape:  {ct.output.shape}")  # triggers corrupted run
+
+    print()
+    print("# What changed")
+    print("  - one context manager instead of two")
+    print("  - patch by short name; the trace handles path-prefix discovery")
+    print("  - clean_output captured up front; output runs on first access")
+    print("  - errors loudly if you try to patch after reading output")
+
+
+if __name__ == "__main__":
+    main()

--- a/mlxterp/core/__init__.py
+++ b/mlxterp/core/__init__.py
@@ -2,6 +2,7 @@
 
 from .proxy import ModuleProxy, OutputProxy, LayerListProxy, TraceContext
 from .trace import Trace
+from .causal_trace import CausalTrace
 from .intervention import (
     zero_out,
     scale,
@@ -26,6 +27,7 @@ __all__ = [
     "TraceContext",
     # Trace
     "Trace",
+    "CausalTrace",
     # Intervention
     "zero_out",
     "scale",

--- a/mlxterp/core/causal_trace.py
+++ b/mlxterp/core/causal_trace.py
@@ -1,0 +1,150 @@
+"""
+Multi-input "causal" trace: clean/corrupted pair tracing.
+
+The standard activation-patching pattern requires capturing activations
+on a clean run, then injecting them into a corrupted run via the
+`replace_with` intervention. This works but is verbose and easy to get
+wrong (missing context manager, wrong key prefix, forgetting to save
+output, etc.). ``CausalTrace`` is the ergonomic wrapper:
+
+    with model.causal_trace(clean_input, corrupted_input) as ct:
+        ct.patch("layers.5.mlp")
+        ct.patch("layers.10.self_attn")
+        patched = ct.output             # corrupted run, with clean
+                                        # activations swapped in at the
+                                        # patched modules
+        clean   = ct.clean_output       # captured during __enter__
+
+Resolves CAUSAL_INTERP_ROADMAP.md Tier 1 #2 (Multi-Input Trace).
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+
+import mlx.core as mx
+
+
+class CausalTrace:
+    """Context manager for clean/corrupted comparative tracing.
+
+    On ``__enter__`` runs a single forward pass over ``clean_input``,
+    capturing every activation. ``patch(module_name)`` schedules a
+    swap-in for the corrupted run. On the first access of ``output``
+    we run the corrupted forward pass with all scheduled patches as
+    ``replace_with`` interventions on top of any user-supplied ones.
+
+    Patches and the corrupted run are deferred so users can call
+    ``patch()`` multiple times in any order before reading the result,
+    and the corrupted forward only runs once even if ``output`` is
+    read repeatedly.
+
+    Args:
+        model: The InterpretableModel being traced.
+        clean_input: Text or token sequence for the clean run.
+        corrupted_input: Text or token sequence for the corrupted run.
+        interventions: Optional dict of additional, user-supplied
+            interventions to apply on the corrupted run alongside the
+            scheduled patches. Same format as
+            ``model.trace(..., interventions=...)``.
+    """
+
+    def __init__(
+        self,
+        model,
+        clean_input,
+        corrupted_input,
+        interventions: Optional[Dict[str, Any]] = None,
+    ):
+        self._model = model
+        self._clean_input = clean_input
+        self._corrupted_input = corrupted_input
+        self._user_interventions: Dict[str, Any] = dict(interventions or {})
+        self._patches: List[str] = []
+        self._clean_activations: Optional[Dict[str, mx.array]] = None
+        self._clean_output: Optional[mx.array] = None
+        self._corrupted_output: Optional[mx.array] = None
+        self._corrupted_run: bool = False
+
+    def __enter__(self) -> "CausalTrace":
+        with self._model.trace(self._clean_input) as t:
+            pass
+        self._clean_activations = dict(t.activations)
+        self._clean_output = self._clean_activations.get("__model_output__")
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        # The corrupted forward (if requested) ran inside the with block on
+        # first .output access; nothing further to clean up. If patches were
+        # scheduled but .output was never accessed, we silently do not run
+        # the corrupted forward — same behaviour as a torch trainer where
+        # you only pay for what you ask for.
+        return False
+
+    def patch(self, module_name: str) -> "CausalTrace":
+        """Schedule a clean→corrupted activation swap for one module.
+
+        Multiple ``patch`` calls compose: each accumulates one more
+        replace_with intervention. Call before reading ``output``.
+        Returns ``self`` to support chaining.
+        """
+        if self._corrupted_run:
+            raise RuntimeError(
+                "Cannot patch after .output has been accessed. The corrupted "
+                "forward already ran with the patches scheduled at that "
+                "point. Schedule all patches before reading .output."
+            )
+        self._patches.append(module_name)
+        return self
+
+    @property
+    def clean_output(self) -> Optional[mx.array]:
+        """The model's output on the clean input, captured during __enter__."""
+        return self._clean_output
+
+    @property
+    def output(self) -> mx.array:
+        """The model's output on the corrupted input with all scheduled
+        patches applied. Lazily triggers the corrupted forward on first
+        access; cached for subsequent reads.
+        """
+        if not self._corrupted_run:
+            self._run_corrupted()
+        return self._corrupted_output
+
+    @property
+    def patches(self) -> List[str]:
+        """The list of scheduled patches, in the order they were added."""
+        return list(self._patches)
+
+    def _run_corrupted(self) -> None:
+        from . import intervention as iv
+
+        interventions = dict(self._user_interventions)
+        for name in self._patches:
+            clean_act = self._lookup_clean_activation(name)
+            interventions[name] = iv.replace_with(clean_act)
+        with self._model.trace(
+            self._corrupted_input, interventions=interventions
+        ) as t:
+            pass
+        self._corrupted_output = t.activations.get("__model_output__")
+        self._corrupted_run = True
+
+    def _lookup_clean_activation(self, name: str) -> mx.array:
+        """Find the clean activation matching ``name``, accommodating the
+        path prefixes that ``trace.activations`` keys use ("model.",
+        "model.model.") relative to what the user types.
+        """
+        if self._clean_activations is None:
+            raise RuntimeError("CausalTrace was not entered before use.")
+        for prefix in ("", "model.", "model.model."):
+            full = f"{prefix}{name}"
+            if full in self._clean_activations:
+                return self._clean_activations[full]
+        sample = list(self._clean_activations.keys())
+        raise KeyError(
+            f"No clean activation captured for module {name!r}. "
+            f"Tried prefixes '', 'model.', 'model.model.'. "
+            f"Sample keys actually captured: {sample[:5]}..."
+        )

--- a/mlxterp/model.py
+++ b/mlxterp/model.py
@@ -8,7 +8,7 @@ import mlx.core as mx
 import mlx.nn as nn
 from typing import Optional, Dict, Callable, Any, Union, List
 
-from .core import Trace, ModuleProxy, LayerListProxy, ModuleResolver
+from .core import Trace, CausalTrace, ModuleProxy, LayerListProxy, ModuleResolver
 from .tokenization import TokenizerMixin
 from .analysis import AnalysisMixin
 from .sae_mixin import SAEMixin
@@ -247,6 +247,50 @@ class InterpretableModel(TokenizerMixin, AnalysisMixin, SAEMixin):
             tokenizer=self.tokenizer,
             interventions=interventions,
             interpretable_model=self,
+        )
+
+    def causal_trace(
+        self,
+        clean_input: Union[str, List[int], mx.array],
+        corrupted_input: Union[str, List[int], mx.array],
+        interventions: Optional[Dict[str, Callable]] = None,
+    ) -> CausalTrace:
+        """Create a comparative clean/corrupted trace context.
+
+        Captures activations on the clean input, then lets you schedule
+        per-module patches that swap clean activations into a corrupted
+        run. Reading ``ct.output`` lazily triggers the corrupted forward
+        with all patches applied. ``ct.clean_output`` is captured up
+        front during ``__enter__``.
+
+        Standard activation-patching pattern, but ergonomic — no manual
+        `replace_with` setup or activation-key prefix juggling.
+
+        Example:
+            >>> with model.causal_trace(
+            ...     clean_input="Paris is the capital of France",
+            ...     corrupted_input="London is the capital of France",
+            ... ) as ct:
+            ...     ct.patch("layers.5.mlp")
+            ...     ct.patch("layers.10.self_attn")
+            ...     patched = ct.output
+            ...     clean = ct.clean_output
+
+        Args:
+            clean_input: Clean run input (text or tokens).
+            corrupted_input: Corrupted run input (text or tokens).
+            interventions: Optional dict of additional interventions to
+                apply to the corrupted run alongside the scheduled
+                patches. Same format as ``model.trace()``.
+
+        Returns:
+            A CausalTrace context manager.
+        """
+        return CausalTrace(
+            model=self,
+            clean_input=clean_input,
+            corrupted_input=corrupted_input,
+            interventions=interventions,
         )
 
     def _forward(self, inputs: mx.array) -> mx.array:

--- a/tests/test_causal_trace.py
+++ b/tests/test_causal_trace.py
@@ -1,0 +1,119 @@
+"""Tests for ``model.causal_trace``: clean/corrupted comparative tracing."""
+
+from __future__ import annotations
+
+import pytest
+
+mx = pytest.importorskip("mlx.core")
+mlx_lm = pytest.importorskip("mlx_lm")
+
+from mlxterp import InterpretableModel
+
+
+MODEL_NAME = "lmstudio-community/Qwen3-4B-Instruct-2507-MLX-8bit"
+CLEAN = "Paris is the capital of France"
+CORRUPTED = "London is the capital of France"
+
+
+@pytest.fixture(scope="module")
+def model_and_tokenizer():
+    base, tok = mlx_lm.load(MODEL_NAME)
+    return base, tok
+
+
+@pytest.fixture(scope="module")
+def interp_model(model_and_tokenizer):
+    base, tok = model_and_tokenizer
+    return InterpretableModel(base, tokenizer=tok)
+
+
+def test_clean_output_captured_on_enter(interp_model):
+    """Clean run executes during __enter__; clean_output is available
+    immediately, even before any patches are scheduled."""
+    with interp_model.causal_trace(CLEAN, CORRUPTED) as ct:
+        assert ct.clean_output is not None
+        # Shape: (batch=1, seq_len, vocab)
+        assert ct.clean_output.ndim == 3
+
+
+def test_corrupted_output_runs_lazily(interp_model):
+    """Corrupted run is deferred until .output is read."""
+    with interp_model.causal_trace(CLEAN, CORRUPTED) as ct:
+        # No patches; output should still be runnable (just unmodified
+        # corrupted run)
+        out = ct.output
+        assert out is not None
+        assert out.shape == ct.clean_output.shape
+
+
+def test_patch_returns_self_for_chaining(interp_model):
+    with interp_model.causal_trace(CLEAN, CORRUPTED) as ct:
+        ret = ct.patch("layers.5")
+        assert ret is ct
+        assert "layers.5" in ct.patches
+
+
+def test_patch_actually_changes_output(interp_model):
+    """A scheduled patch should produce a different corrupted output
+    than an unpatched corrupted run."""
+    # No patches: just baseline corrupted
+    with interp_model.causal_trace(CLEAN, CORRUPTED) as ct_none:
+        unpatched = ct_none.output
+
+    # With a mid-network patch
+    with interp_model.causal_trace(CLEAN, CORRUPTED) as ct_patched:
+        ct_patched.patch("layers.5")
+        patched = ct_patched.output
+
+    # Outputs should differ since we swapped a layer's activation
+    diff = float(mx.linalg.norm(unpatched - patched))
+    assert diff > 0.0, (
+        "Patching layers.5 didn't change the output. Either the patch "
+        "didn't apply, or layers.5 makes no contribution at all (very "
+        "unlikely). Either way, regression."
+    )
+
+
+def test_patch_after_output_raises(interp_model):
+    """Calling patch() after .output has been read should error
+    rather than silently dropping the patch."""
+    with interp_model.causal_trace(CLEAN, CORRUPTED) as ct:
+        _ = ct.output  # triggers corrupted run
+        with pytest.raises(RuntimeError, match="after \\.output"):
+            ct.patch("layers.7")
+
+
+def test_unknown_module_path_raises_keyerror(interp_model):
+    """A patch on a nonexistent module should raise KeyError when the
+    corrupted run tries to look up the clean activation."""
+    with interp_model.causal_trace(CLEAN, CORRUPTED) as ct:
+        ct.patch("layers.999.nonexistent")
+        with pytest.raises(KeyError, match="No clean activation"):
+            _ = ct.output
+
+
+def test_user_interventions_compose_with_patches(interp_model):
+    """User-supplied interventions on the corrupted run apply alongside
+    the scheduled patches, not instead of them."""
+    from mlxterp import interventions as iv
+
+    with interp_model.causal_trace(
+        CLEAN, CORRUPTED, interventions={"layers.10": iv.scale(0.5)}
+    ) as ct:
+        ct.patch("layers.5")
+        out = ct.output
+    assert out is not None
+    # We can't easily assert exact values, but the call shouldn't error
+    # and the output should be a same-shaped array.
+    assert out.ndim == 3
+
+
+def test_output_is_idempotent(interp_model):
+    """Reading .output twice must not re-run the corrupted forward
+    (the lazy cache should hold)."""
+    with interp_model.causal_trace(CLEAN, CORRUPTED) as ct:
+        ct.patch("layers.5")
+        first = ct.output
+        second = ct.output
+    diff = float(mx.linalg.norm(first - second))
+    assert diff == 0.0


### PR DESCRIPTION
Implements `CAUSAL_INTERP_ROADMAP.md` Tier 1 item 2 (Multi-Input Trace) — the ergonomic clean/corrupted pair API. Three of five checkboxes ticked; two deferred (see below).

This PR is independent of #10 (Text Generation with Interventions) and #11 (Activation Patching API) — branches off `main`, touches different files.

## Summary

Replaces the verbose two-trace activation-patching pattern with one context manager:

```python
# Before (verbose, error-prone):
with model.trace(clean) as t:
    clean_l5 = t.activations["model.model.layers.5.mlp"]
with model.trace(corrupted, interventions={
    "layers.5.mlp": replace_with(clean_l5)
}):
    patched = model.output.save()

# After (the new API):
with model.causal_trace(clean, corrupted) as ct:
    ct.patch("layers.5.mlp")
    patched = ct.output
    clean = ct.clean_output
```

The `CausalTrace` class in `mlxterp/core/causal_trace.py`:

- Runs the clean trace during `__enter__`, captures all activations
- Defers the corrupted trace until first `.output` access (lazy)
- Accumulates patches via `.patch()` in any order
- Resolves short module names against the captured activation dict's prefixed keys (`"model."`, `"model.model."`) automatically
- User-supplied `interventions={...}` on the corrupted run compose with the scheduled patches rather than replacing them

## What's deferred

- **`.metric(fn)` inline causal-effect computation** — users still invoke metrics by hand on `ct.output` and `ct.clean_output`. Built-in metrics (`logit_diff`, `kl_divergence`, `cross_entropy_diff`) ship in #11 (Activation Patching) where they're more directly useful. If you'd like them on `CausalTrace` too, happy to add.
- **Batched k-corruptions-in-one-call** — orthogonal to the clean/corrupted pair API; would need input batching support throughout the trace machinery. Multiple `.patch()` calls already compose for one corrupted run.

## Edge cases covered

- `.patch()` after `.output` access raises `RuntimeError` (catches the silent-drop bug where users add patches after the corrupted run already happened)
- Lookup of a nonexistent module path raises `KeyError` with sample keys in the message
- `.output` is idempotent: reading it twice runs the corrupted forward exactly once
- `ct.clean_output` is available immediately after `__enter__` so users can inspect both runs side by side

## Files changed

- `mlxterp/core/causal_trace.py` (+148): new `CausalTrace` class
- `mlxterp/core/__init__.py` (+2): export `CausalTrace`
- `mlxterp/model.py` (+44): new `InterpretableModel.causal_trace()` method
- `CAUSAL_INTERP_ROADMAP.md` (+11, -5): tick checkboxes with notes
- `tests/test_causal_trace.py` (+108): 8 contract tests (force-added per `test_*.py` gitignore)
- `examples/causal_trace.py` (+50): verbose-vs-ergonomic comparison

## Notes for review

- **Test file force-added** for the same reason as #10 and #11 (the repo's `.gitignore` has `test_*.py`).
- **Test fixture model** is Qwen3-4B-Instruct-MLX-8bit (4 GB) — happy to swap to a smaller default if you have a preferred CI fixture.
- **`.metric(fn)` API is open for design feedback.** I left it out because it's easy to invoke a custom metric on `(ct.output, ct.clean_output)` from user code, and `model.activation_patching` from #11 already has the built-in causal metrics that researchers actually want. But if you'd prefer the metric helper land here, it's a small follow-up.

Built and tested as part of the [AJAR Hidden CoT detection project](https://github.com/edward-lcl/AJAR), the same downstream consumer that ran the 5/5 parity test on top of #10 and #11.