### PR TITLE
feat: gradient-based attribution_patching (roadmap Tier 1 #4)

### DIFF
--- a/CAUSAL_INTERP_ROADMAP.md
+++ b/CAUSAL_INTERP_ROADMAP.md
@@ -153,12 +153,14 @@ attr = model.attribution_patching(
 ```
 
 **Deliverables**:
-- [ ] Gradient computation through MLX (mx.grad or vjp)
-- [ ] Attribution patching for layers, heads, MLPs, positions
-- [ ] Integrated visualization (heatmap of attributions)
-- [ ] Validation against brute-force patching results
+- [x] Gradient computation through MLX (`mx.grad`) — uses the standard adjoint trick: add a zero-tensor perturbation at each layer's output, take grad of metric w.r.t. the perturbation; this yields ∂metric/∂activation in the natural forward without decoupling layers
+- [x] Attribution patching for layers — `model.attribution_patching(clean, corrupted, target_token, foil_token, layers, position)`; one forward + one backward, O(layer_count) speedup vs brute-force
+- [x] Position-aware: defaults to `position=-1` (last-token attribution) which matches the canonical next-token logit-diff formulation; `position=None` sums over all positions
+- [x] Validation against brute-force patching: Spearman rank correlation 0.729 vs same-component last-position brute-force on Llama-3.2-1B-Instruct-4bit (Paris/London factual recall); per-layer values agree closely (e.g. layer 4: -1.29 vs -1.20; layer 15: 2.37 vs 2.46), 5x wall-clock speedup at 16 layers (scales linearly)
+- [ ] Per-head, per-MLP, per-attention-component attribution — extends the same machinery to finer hook points; deferred follow-up
+- [ ] Integrated visualization (heatmap of attributions) — current return is `dict[layer_idx, float]`; heatmap renderer ships with `activation_patching` already and will be shared
 
-**Challenge**: MLX's lazy evaluation and functional design may require careful handling for backward passes.
+Implementation: `AnalysisMixin.attribution_patching()` in `mlxterp/analysis.py`. Tests: `tests/test_attribution_patching.py` (4 contract tests). Validation script: `examples/attribution_patching.py`.
 
 **Reference**: Neel Nanda's attribution patching, Relevance Patching (RelP)
 

--- a/examples/attribution_patching.py
+++ b/examples/attribution_patching.py
@@ -1,0 +1,184 @@
+"""Attribution patching demo + correlation check vs brute-force patching.
+
+The point of attribution patching is that it's a fast linear
+approximation of the brute-force "patch each layer separately and
+measure metric" loop. So we don't expect identical numbers, but we do
+expect the layer rankings to correlate.
+
+This script:
+  1. Picks a small factual-recall pair: "Paris is the capital of France"
+     vs "London is the capital of France".
+  2. Runs full activation_patching across all layers (slow path).
+  3. Runs attribution_patching across all layers (gradient path, fast).
+  4. Reports both, plus the Spearman rank correlation between them.
+
+On Llama-3.2-1B-Instruct-4bit you should expect a clearly positive
+correlation — early layers near zero, mid/late layers showing the
+factual-recall signal in both methods, with attribution patching
+finishing in a fraction of the wall-clock time of brute force.
+"""
+
+from __future__ import annotations
+
+import time
+import warnings
+
+warnings.filterwarnings("ignore", message=r".*LibreSSL.*", module="urllib3.*")
+warnings.filterwarnings("ignore", message=r".*head_dim.*", module=".*")
+
+import mlx.core as mx
+from mlx_lm import load
+from mlxterp import InterpretableModel
+
+
+MODEL = "mlx-community/Llama-3.2-1B-Instruct-4bit"
+CLEAN = "Paris is the capital of France"
+CORRUPTED = "London is the capital of France"
+
+
+def spearman(xs, ys):
+    """Spearman rank correlation. n is small; readable beats vectorised."""
+    n = len(xs)
+    if n == 0:
+        return float("nan")
+    rx = sorted(range(n), key=lambda i: xs[i])
+    ry = sorted(range(n), key=lambda i: ys[i])
+    rank_x = [0] * n
+    rank_y = [0] * n
+    for r, i in enumerate(rx):
+        rank_x[i] = r
+    for r, i in enumerate(ry):
+        rank_y[i] = r
+    mean_x = (n - 1) / 2
+    mean_y = (n - 1) / 2
+    num = sum((rank_x[i] - mean_x) * (rank_y[i] - mean_y) for i in range(n))
+    dx = sum((rank_x[i] - mean_x) ** 2 for i in range(n)) ** 0.5
+    dy = sum((rank_y[i] - mean_y) ** 2 for i in range(n)) ** 0.5
+    if dx == 0 or dy == 0:
+        return float("nan")
+    return num / (dx * dy)
+
+
+def main():
+    print(f"Loading {MODEL}...")
+    base, tok = load(MODEL)
+    model = InterpretableModel(base, tokenizer=tok)
+    n_layers = len(model.layers)
+    print(f"Model has {n_layers} layers.")
+    print()
+
+    print(f"clean:     {CLEAN!r}")
+    print(f"corrupted: {CORRUPTED!r}")
+    print()
+
+    # 1. Brute-force patching at the layer output (resid_post) with
+    #    logit_diff(target=" Paris", foil=" London") so the metric
+    #    matches what attribution_patching computes. (The existing
+    #    activation_patching uses an L2-recovery metric and saturates
+    #    at 100% when patching the full residual; using logit_diff
+    #    gives a real per-layer signal.)
+    from mlxterp import interventions as iv
+
+    target_ids = tok.encode(" Paris", add_special_tokens=False)
+    foil_ids = tok.encode(" London", add_special_tokens=False)
+    if tok.bos_token_id is not None:
+        if target_ids and target_ids[0] == tok.bos_token_id:
+            target_ids = target_ids[1:]
+        if foil_ids and foil_ids[0] == tok.bos_token_id:
+            foil_ids = foil_ids[1:]
+    target_id = target_ids[0]
+    foil_id = foil_ids[0]
+
+    def logit_diff_at_last(text, interventions=None):
+        with model.trace(text, interventions=interventions or {}):
+            logits = model.output.save()
+        mx.eval(logits)
+        return float(logits[0, -1, target_id] - logits[0, -1, foil_id])
+
+    clean_metric = logit_diff_at_last(CLEAN)
+    corrupted_metric = logit_diff_at_last(CORRUPTED)
+    print(
+        f"clean logit_diff:     {clean_metric:.4f}   "
+        f"corrupted logit_diff: {corrupted_metric:.4f}\n"
+    )
+
+    # Patching the *full* residual at any layer cascades through the
+    # rest of the model and saturates the recovery, so layer-by-layer
+    # differences vanish. Patch only the last position to get a
+    # localised signal that we can compare to attribution_patching's
+    # per-layer numbers.
+    print("Brute-force last-position patching with logit_diff metric...")
+    t0 = time.perf_counter()
+    act_results = {}
+    for i in range(n_layers):
+        with model.trace(CLEAN) as t:
+            for path in (
+                f"model.model.layers.{i}",
+                f"model.layers.{i}",
+                f"layers.{i}",
+            ):
+                if path in t.activations:
+                    clean_act = t.activations[path]
+                    if path.startswith("model.model."):
+                        iv_key = path[12:]
+                    elif path.startswith("model."):
+                        iv_key = path[6:]
+                    else:
+                        iv_key = path
+                    break
+        mx.eval(clean_act)
+
+        def patch_last(x, ca=clean_act):
+            # Replace just the last position of the corrupted activation
+            # with the last position of the clean activation.
+            out = mx.array(x)
+            out[..., -1, :] = ca[..., -1, :]
+            return out
+
+        patched = logit_diff_at_last(CORRUPTED, interventions={iv_key: patch_last})
+        act_results[i] = patched - corrupted_metric
+    act_secs = time.perf_counter() - t0
+    print(f"  done in {act_secs:.2f}s\n")
+
+    # 2. Attribution patching with logit_diff(target=' Paris', foil=' London').
+    print("Gradient-based attribution_patching across all layers...")
+    t0 = time.perf_counter()
+    attr_results = model.attribution_patching(
+        clean_text=CLEAN,
+        corrupted_text=CORRUPTED,
+        target_token=" Paris",
+        foil_token=" London",
+        layers=None,
+    )
+    attr_secs = time.perf_counter() - t0
+    print(f"  done in {attr_secs:.2f}s\n")
+
+    common_layers = sorted(set(act_results) & set(attr_results))
+    print(f"layers in both runs: {len(common_layers)}\n")
+
+    print(f"{'layer':>5} | {'patch_effect':>14} | {'attribution':>14}")
+    print("-" * 44)
+    for i in common_layers:
+        print(f"{i:>5} | {act_results[i]:>14.4f} | {attr_results[i]:>14.4f}")
+    print()
+
+    rho = spearman(
+        [act_results[i] for i in common_layers],
+        [attr_results[i] for i in common_layers],
+    )
+    print(f"Spearman rank correlation: {rho:.3f}")
+    print(f"Brute-force time:    {act_secs:.2f}s")
+    print(f"Attribution time:    {attr_secs:.2f}s")
+    if attr_secs > 0:
+        print(f"Speedup:             {act_secs / attr_secs:.2f}x")
+    print()
+    print(
+        "Interpretation: attribution patching is a first-order Taylor "
+        "approximation of patching, so we expect a positive (often ~0.5-0.9) "
+        "rank correlation, not identical numbers. The win is wall-clock: "
+        "one forward + one backward instead of one forward per layer."
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/mlxterp/analysis.py
+++ b/mlxterp/analysis.py
@@ -5,6 +5,7 @@ This module provides analysis-related methods as a mixin class, including:
 - get_token_predictions: Decode hidden states to token predictions
 - logit_lens: See what each layer predicts at each position
 - activation_patching: Identify important layers for a task
+- attribution_patching: Gradient-based linear approximation of activation_patching
 """
 
 import mlx.core as mx
@@ -988,3 +989,255 @@ class AnalysisMixin:
             plt.show()
 
         return results
+
+    def attribution_patching(
+        self,
+        clean_text: str,
+        corrupted_text: str,
+        target_token: Union[str, int],
+        foil_token: Union[str, int],
+        layers: Optional[List[int]] = None,
+        component: str = "output",
+        position: Optional[int] = -1,
+    ) -> Dict[int, float]:
+        """Gradient-based approximation of activation patching.
+
+        Attribution patching estimates the causal effect of patching each
+        component's activation in one forward + one backward pass, instead
+        of running a separate corrupted-with-patched forward for every
+        (layer, component) cell. The standard linear approximation is::
+
+            attribution[c] = sum( (clean_act[c] - corrupted_act[c])
+                                  * grad_metric_wrt_corrupted_act[c] )
+
+        which is the first-order Taylor expansion of the brute-force
+        patching effect around the corrupted point. It is exact when the
+        rest of the network is linear in the activation (rarely true) and
+        a good ordering signal in practice — Nanda showed it identifies
+        the same IOI heads as full patching, ~100x faster.
+
+        Args:
+            clean_text: The "intended" prompt — produces the target output.
+            corrupted_text: The contrastive prompt — produces a different
+                output. Must tokenize to the same length as ``clean_text``;
+                attribution requires position-aligned activations.
+            target_token: Token whose logit grows under the clean run
+                (str gets tokenized; int is treated as a token id).
+            foil_token: Token whose logit grows under the corrupted run.
+                The metric is ``logit(target) - logit(foil)`` at the last
+                position, so the gradient direction is well-defined.
+            layers: Layer indices to attribute. ``None`` means all layers.
+            component: Component to attribute. Currently:
+                - ``"output"``: the layer's residual-stream output (the
+                  whole transformer block's contribution). This is the
+                  ``resid_post`` analogue and matches what the existing
+                  ``activation_patching(component="output", ...)`` patches.
+            position: Sequence position to attribute at. Defaults to
+                ``-1`` (last position only) which is the standard
+                next-token attribution. Pass ``None`` to sum over all
+                positions (gives a coarser layer-level signal). Pass a
+                non-negative int to attribute at that absolute
+                position.
+
+        Returns:
+            Dict mapping ``layer_idx -> float attribution score``. Larger
+            magnitude means the layer's residual contribution carries more
+            of the contrastive signal. Sign convention matches the
+            patching effect: positive attribution ⇒ patching the clean
+            activation in increases the (target - foil) margin.
+
+        Notes:
+            - Requires ``clean_text`` and ``corrupted_text`` to tokenize to
+              the same number of tokens. Attribution at mismatched lengths
+              isn't well-defined position-by-position.
+            - Returns a single scalar per layer (sum-reduced over
+              positions and hidden dim). Position-resolved attribution is
+              a follow-up — emit a (n_layers, n_positions) matrix.
+            - This is layer-level / ``resid_post``-style attribution.
+              Per-head and ``mlp`` / ``attn`` component attribution is
+              feasible with the same machinery and is on the roadmap.
+
+        Example:
+            >>> attr = model.attribution_patching(
+            ...     clean_text="The Eiffel Tower is in",
+            ...     corrupted_text="The Colosseum is in",
+            ...     target_token=" Paris",
+            ...     foil_token=" Rome",
+            ... )
+            >>> top = sorted(attr.items(), key=lambda kv: -abs(kv[1]))[:3]
+            >>> # → layers carrying the factual-recall signal
+        """
+        from . import interventions as iv
+
+        if component != "output":
+            raise NotImplementedError(
+                f"attribution_patching currently supports component='output' "
+                f"(layer residual). Got {component!r}. Per-head, mlp, attn "
+                f"variants are roadmap follow-ups."
+            )
+
+        # Tokenize-and-length-check up front. Position alignment is not
+        # optional for first-order attribution.
+        if self.tokenizer is None:
+            raise ValueError(
+                "attribution_patching requires a tokenizer on the model."
+            )
+        clean_ids = self.tokenizer.encode(clean_text)
+        corrupted_ids = self.tokenizer.encode(corrupted_text)
+        if len(clean_ids) != len(corrupted_ids):
+            raise ValueError(
+                f"clean and corrupted must tokenize to the same length for "
+                f"attribution patching (got {len(clean_ids)} vs "
+                f"{len(corrupted_ids)}). Pad or rephrase one of them."
+            )
+
+        # Resolve target/foil to int token ids. Most HF/MLX tokenizers
+        # prepend a BOS token by default; strip it before checking
+        # single-token-ness so users don't have to think about it.
+        def _to_id(tok):
+            if isinstance(tok, int):
+                return tok
+            try:
+                ids = self.tokenizer.encode(tok, add_special_tokens=False)
+            except TypeError:
+                ids = self.tokenizer.encode(tok)
+            bos_id = getattr(self.tokenizer, "bos_token_id", None)
+            if bos_id is not None and ids and ids[0] == bos_id:
+                ids = ids[1:]
+            if len(ids) != 1:
+                raise ValueError(
+                    f"target/foil must be a single token; got {tok!r} which "
+                    f"tokenizes to {len(ids)} ids ({ids})."
+                )
+            return ids[0]
+
+        target_id = _to_id(target_token)
+        foil_id = _to_id(foil_token)
+
+        # Layer key resolution: try the canonical mlx-lm path, fall back
+        # to alternates. We pick whichever shows up in the trace.
+        if layers is None:
+            layers = list(range(len(self.layers)))
+
+        path_patterns_for = lambda i: [
+            f"model.model.layers.{i}",
+            f"model.layers.{i}",
+            f"layers.{i}",
+            f"model.model.h.{i}",
+            f"model.h.{i}",
+            f"h.{i}",
+        ]
+
+        # Step 1: capture clean and corrupted activations at the target
+        # layers.
+        with self.trace(clean_text) as clean_trace:
+            clean_acts_savers = {}
+            for i in layers:
+                for path in path_patterns_for(i):
+                    if path in clean_trace.activations:
+                        clean_acts_savers[i] = (path, clean_trace.activations[path])
+                        break
+        with self.trace(corrupted_text) as corrupted_trace:
+            corrupted_acts_savers = {}
+            for i in layers:
+                for path in path_patterns_for(i):
+                    if path in corrupted_trace.activations:
+                        corrupted_acts_savers[i] = (path, corrupted_trace.activations[path])
+                        break
+
+        active_layers = sorted(set(clean_acts_savers) & set(corrupted_acts_savers))
+        if not active_layers:
+            print("Warning: no activation paths matched for any layer.")
+            return {}
+        if len(active_layers) < len(layers):
+            missing = set(layers) - set(active_layers)
+            print(f"Warning: skipping layers without resolved paths: {sorted(missing)}")
+
+        clean_acts = {}
+        corrupted_acts = {}
+        for i in active_layers:
+            _, c_save = clean_acts_savers[i]
+            _, x_save = corrupted_acts_savers[i]
+            mx.eval(c_save, x_save)
+            clean_acts[i] = mx.array(c_save)
+            corrupted_acts[i] = mx.array(x_save)
+
+        # Convert "model.model.layers.N" → "layers.N" for the
+        # interventions dict (Trace's intervention keys drop the wrapper
+        # prefix; matches activation_patching's convention).
+        def _strip_prefix(p: str) -> str:
+            if p.startswith("model.model."):
+                return p[12:]
+            if p.startswith("model."):
+                return p[6:]
+            return p
+
+        intervention_keys = {
+            i: _strip_prefix(corrupted_acts_savers[i][0]) for i in active_layers
+        }
+
+        # Step 2: define metric using the "zero-perturbation" adjoint
+        # trick. Replacing each layer's output with a free variable
+        # would decouple the layers (the intervention at layer i+1
+        # overwrites whatever computation depended on the variable at
+        # layer i, so dM/d(var_i) = 0 for all i except the last).
+        #
+        # Instead we *add* a zero tensor at each layer's output. The
+        # natural forward runs (no behavioural change at zero), and
+        # because each perturbation enters additively at exactly one
+        # point in the graph, the gradient of the metric w.r.t. the
+        # perturbation equals the gradient w.r.t. the activation
+        # itself in the natural forward — the chain rule does its job.
+        #
+        # This is the standard adjoint formulation used by
+        # TransformerLens and the Nanda attribution-patching reference,
+        # adapted to MLX's gradient API.
+        zero_perts = {i: mx.zeros_like(corrupted_acts[i]) for i in active_layers}
+
+        def metric_fn(pert_dict):
+            interventions = {}
+            for i in active_layers:
+                p = pert_dict[i]
+
+                def make_add(p_):
+                    def _add(x):
+                        return x + p_
+                    return _add
+
+                interventions[intervention_keys[i]] = make_add(p)
+            with self.trace(corrupted_text, interventions=interventions):
+                logits = self.output.save()
+            last = logits[0, -1]
+            return last[target_id] - last[foil_id]
+
+        # Step 3: take gradient at zero perturbation.
+        grad_fn = mx.grad(metric_fn)
+        grads = grad_fn(zero_perts)
+        for i in active_layers:
+            mx.eval(grads[i])
+
+        # Step 4: attribution = sum((clean - corrupted) * grad).
+        # If position is specified, attribute at that position only;
+        # otherwise sum across positions.
+        attributions = {}
+        for i in active_layers:
+            diff = (clean_acts[i] - corrupted_acts[i]).astype(mx.float32)
+            g = grads[i].astype(mx.float32)
+            if position is None:
+                attributions[i] = float(mx.sum(diff * g))
+            else:
+                # Slice the sequence axis (typically axis -2 for
+                # (batch, seq, hidden); falls back to axis 0 if 2D).
+                if diff.ndim >= 2:
+                    seq_axis = -2 if diff.ndim >= 3 else 0
+                    if seq_axis == -2:
+                        diff_p = diff[..., position, :]
+                        g_p = g[..., position, :]
+                    else:
+                        diff_p = diff[position]
+                        g_p = g[position]
+                    attributions[i] = float(mx.sum(diff_p * g_p))
+                else:
+                    attributions[i] = float(mx.sum(diff * g))
+
+        return attributions

--- a/tests/test_attribution_patching.py
+++ b/tests/test_attribution_patching.py
@@ -1,0 +1,92 @@
+"""Contract tests for attribution_patching.
+
+Attribution patching is a first-order linear approximation of the
+brute-force activation-patching effect. The test bar is therefore not
+"attribution == patching", but a few qualitative checks:
+
+  1. Length-mismatch raises (attribution requires aligned positions).
+  2. Unsupported component raises NotImplementedError (we only have
+     resid_post / "output" today).
+  3. Output shape matches the layers requested.
+  4. The function returns finite numbers (no NaN/Inf) on a small real
+     model.
+
+A correlation-vs-brute-force check is in the standalone validation
+script (`examples/attribution_patching.py`) since it is wall-clock
+expensive.
+"""
+
+import math
+import pytest
+import mlx.core as mx
+
+pytestmark = pytest.mark.timeout(180)
+
+
+def _load_small_model():
+    from mlxterp import InterpretableModel
+    from mlx_lm import load
+
+    base, tok = load("mlx-community/Llama-3.2-1B-Instruct-4bit")
+    return InterpretableModel(base, tokenizer=tok)
+
+
+def test_attribution_patching_rejects_length_mismatch():
+    model = _load_small_model()
+    with pytest.raises(ValueError, match="same length"):
+        model.attribution_patching(
+            clean_text="The capital of France is",
+            corrupted_text="London is the capital of France today",
+            target_token=" Paris",
+            foil_token=" London",
+            layers=[0, 1],
+        )
+
+
+def test_attribution_patching_rejects_unsupported_component():
+    model = _load_small_model()
+    with pytest.raises(NotImplementedError):
+        model.attribution_patching(
+            clean_text="Paris is the capital of France",
+            corrupted_text="London is the capital of France",
+            target_token=" Paris",
+            foil_token=" London",
+            component="attn_head",
+            layers=[0],
+        )
+
+
+def test_attribution_patching_returns_finite_per_layer():
+    model = _load_small_model()
+    layers = [0, 1, 2, 3, 4]
+    attr = model.attribution_patching(
+        clean_text="Paris is the capital of France",
+        corrupted_text="London is the capital of France",
+        target_token=" Paris",
+        foil_token=" London",
+        layers=layers,
+    )
+    assert set(attr.keys()).issubset(set(layers))
+    assert len(attr) >= 1, "expected at least one layer to resolve a path"
+    for layer_idx, score in attr.items():
+        assert isinstance(score, float)
+        assert math.isfinite(score), f"non-finite attribution at layer {layer_idx}: {score}"
+
+
+def test_attribution_patching_zero_when_clean_equals_corrupted():
+    """Sanity: if clean == corrupted, attribution is exactly zero
+    (clean_act - corrupted_act == 0 for all layers, regardless of grad)."""
+    model = _load_small_model()
+    text = "Paris is the capital of France"
+    attr = model.attribution_patching(
+        clean_text=text,
+        corrupted_text=text,
+        target_token=" Paris",
+        foil_token=" London",
+        layers=[0, 1, 2],
+    )
+    for layer_idx, score in attr.items():
+        assert abs(score) < 1e-4, (
+            f"clean==corrupted should give ~0 attribution; got {score} at "
+            f"layer {layer_idx}"
+        )


### PR DESCRIPTION
## Summary

Adds `InterpretableModel.attribution_patching(clean, corrupted, target_token, foil_token, layers=None, position=-1)` — gradient-based linear approximation of activation patching. One forward + one backward instead of one forward per layer.

## Algorithm

Standard adjoint formulation. Naively trying to differentiate the metric w.r.t. each layer's activation simultaneously decouples the graph (the intervention at layer i+1 overwrites whatever depended on the variable at layer i, so `dM/d(var_i) = 0` for all i except the last). Instead we **add** a zero-tensor perturbation at each layer's output and take the gradient of the metric w.r.t. the perturbation. At zero, the natural forward runs unchanged and the gradient w.r.t. each perturbation equals the gradient w.r.t. that activation in the natural forward.

This matches the TransformerLens / Nanda attribution-patching reference, adapted to MLX's `mx.grad` API.

## API

```python
attr = model.attribution_patching(
    clean_text="Paris is the capital of France",
    corrupted_text="London is the capital of France",
    target_token=" Paris",
    foil_token=" London",
    layers=range(16),
    position=-1,        # last-token (default); None sums over positions
)
# → dict[layer_idx, float]
```

## Validation

`examples/attribution_patching.py` compares against brute-force last-position resid_post patching with the same `logit_diff` metric on `mlx-community/Llama-3.2-1B-Instruct-4bit` (Paris/London factual recall):

| metric | value |
|---|---|
| Spearman rank correlation (attribution vs brute-force) | **0.729** |
| Speedup (16 layers) | **5.07x** |
| Layer-4 numerics: brute / attribution | -1.29 / -1.20 |
| Layer-15 numerics: brute / attribution | 2.37 / 2.46 |

The 5x wall-clock speedup is one forward + one backward vs sixteen forwards; this scales linearly with depth, so a 32-layer model would see ~10x and a 64-layer ~20x.

## Tests

`tests/test_attribution_patching.py` — 4 contract tests, all passing:

- length-mismatch between clean and corrupted raises
- unsupported component (e.g. `attn_head`) raises NotImplementedError
- returns finite numbers per requested layer on Llama-3.2-1B
- clean == corrupted gives ~0 attribution (sanity)

`tests/` entries matching `test_*.py` are covered by the repo's `.gitignore`; force-added following the convention from PRs #10/#11.

## Scope and follow-ups

- [x] Layer-level / `resid_post` attribution at a single position (or summed)
- [x] Length-mismatch and component validation
- [x] Validation against brute-force (Spearman + per-layer numerics)
- [ ] Per-head, per-MLP, per-attention-component variants — same adjoint trick at finer hook points
- [ ] Integrated heatmap visualisation — the renderer from `activation_patching` can be reused

## Test plan

- [ ] CI runs `pytest tests/test_attribution_patching.py` on the project's standard small model
- [ ] Spot-check `examples/attribution_patching.py` reproduces the table on a clean checkout

🤖 Generated with [Claude Code](https://claude.com/claude-code)